### PR TITLE
Add slash command support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv/
+.venv/
 .idea/
 __pycache__/
 typings/
@@ -6,3 +7,4 @@ typings/
 build/
 *.egg-info/
 config.yml
+uv.lock

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Now that you have started the bot, you can change its settings from inside Disco
 
 **Contact**  
 If you need to get in contact with me for any reason, feel free to send me a message via Discord, Twitter, or leave an issue on this repository if applicable. That said, your best bet is probably to reach me on Discord. If the fact that I made a framework for Discord bots didn't give it away, I use Discord *a lot*.  
-> Discord: Travus#8888  
+> Discord: travus
 > Twitter: [@RealTravus](https://twitter.com/realtravus)  
 > [Open a GitHub Issue](https://github.com/Travus/Travus_Bot_Base/issues/new)  
 > Email: tbb@travus.dev  

--- a/core_commands.py
+++ b/core_commands.py
@@ -1,9 +1,11 @@
+# pylint: disable=too-many-lines
 import logging
 from asyncio import sleep as asleep  # For waiting asynchronously.
 from os import listdir  # To check files on disk.
 
+import discord
 from asyncpg import IntegrityConstraintViolationError  # To check for database conflicts.
-from discord import Embed
+from discord import Embed, Interaction, app_commands
 from discord.ext import commands  # For implementation of bot commands.
 
 import travus_bot_base as tbb  # TBB functions and classes.
@@ -12,25 +14,77 @@ from travus_bot_base import clean  # Shorthand for cleaning output.
 
 async def setup(bot: tbb.TravusBotBase):
     """Setup function ran when module is loaded."""
-    await bot.add_cog(CoreFunctionalityCog(bot))  # Add cog and command help info.
+    cog = CoreFunctionalityCog(bot)
+    await bot.add_cog(cog)  # Add cog and command help info.
+    # Core commands with slash versions managed by _apply_core_commands_mode.
+    # pylint: disable-next=protected-access
+    bot._core_slash_commands.extend(
+        [cog.slash_about, cog.slash_usage, cog.slash_module, cog.slash_default, cog.slash_config, cog.slash_command]
+    )
+    # pylint: disable-next=protected-access
+    bot._core_prefix_commands.extend([cog.about, cog.usage, cog.module, cog.default, cog.config, cog.command])
     bot.add_command_help(CoreFunctionalityCog.module_list, "Core", {"perms": ["Administrator"]}, [""])
     bot.add_command_help(CoreFunctionalityCog.module_load, "Core", {"perms": ["Administrator"]}, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.module_unload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.module_reload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.module_lasterror, "Core", {"perms": ["Administrator"]}, [""])
+    bot.add_command_help(CoreFunctionalityCog.slash_module_list, "Core", {"perms": ["Administrator"]}, [""])
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_module_load, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
+    )
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_module_unload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
+    )
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_module_reload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
+    )
+    bot.add_command_help(CoreFunctionalityCog.slash_module_lasterror, "Core", {"perms": ["Administrator"]}, [""])
     bot.add_command_help(CoreFunctionalityCog.default, "Core", None, ["list", "add", "remove"])
     bot.add_command_help(CoreFunctionalityCog.default_list, "Core", None, [""])
     bot.add_command_help(CoreFunctionalityCog.default_add, "Core", None, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.default_remove, "Core", None, ["fun", "economy"])
+    bot.add_command_help(CoreFunctionalityCog.slash_default_list, "Core", {"perms": ["Administrator"]}, [""])
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_default_add, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
+    )
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_default_remove, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
+    )
     bot.add_command_help(CoreFunctionalityCog.command_enable, "Core", {"perms": ["Administrator"]}, ["balance", "pay"])
     bot.add_command_help(CoreFunctionalityCog.command_disable, "Core", {"perms": ["Administrator"]}, ["balance", "pay"])
     bot.add_command_help(CoreFunctionalityCog.command_show, "Core", {"perms": ["Administrator"]}, ["module", "balance"])
     bot.add_command_help(CoreFunctionalityCog.command_hide, "Core", {"perms": ["Administrator"]}, ["module", "balance"])
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_command_enable, "Core", {"perms": ["Administrator"]}, ["balance", "pay"]
+    )
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_command_disable, "Core", {"perms": ["Administrator"]}, ["balance", "pay"]
+    )
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_command_show, "Core", {"perms": ["Administrator"]}, ["module", "balance"]
+    )
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_command_hide, "Core", {"perms": ["Administrator"]}, ["module", "balance"]
+    )
     bot.add_command_help(CoreFunctionalityCog.about, "Core", None, ["", "fun"])
+    bot.add_command_help(CoreFunctionalityCog.slash_about, "Core", None, ["", "dev"])
     bot.add_command_help(CoreFunctionalityCog.usage, "Core", None, ["", "dev"])
+    bot.add_command_help(CoreFunctionalityCog.slash_usage, "Core", None, ["", "dev"])
     bot.add_command_help(CoreFunctionalityCog.config, "Core", {"perms": ["Administrator"]}, ["get", "set", "unset"])
-    bot.add_command_help(CoreFunctionalityCog.config_get, "Core", {"perms": ["Administrator"]}, ["alert_channel"])
+    bot.add_command_help(CoreFunctionalityCog.config_get, "Core", {"perms": ["Administrator"]}, ["", "alert_channel"])
     bot.add_command_help(CoreFunctionalityCog.config_unset, "Core", {"perms": ["Administrator"]}, ["alert_channel"])
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_config_get, "Core", {"perms": ["Administrator"]}, ["", "alert_channel"]
+    )
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_config_set,
+        "Core",
+        {"perms": ["Administrator"]},
+        ["alert_channel 353246496952418305"],
+    )
+    bot.add_command_help(
+        CoreFunctionalityCog.slash_config_unset, "Core", {"perms": ["Administrator"]}, ["alert_channel"]
+    )
     bot.add_command_help(CoreFunctionalityCog.shutdown, "Core", None, ["", "1h", "1h30m", "10m-30s", "2m30s"])
     bot.add_command_help(CoreFunctionalityCog.botconfig_prefix, "Core", None, ["$", "bot!", "bot ?", "remove"])
     bot.add_command_help(CoreFunctionalityCog.botconfig_deletemessages, "Core", None, ["enable", "y", "disable", "n"])
@@ -64,6 +118,11 @@ async def setup(bot: tbb.TravusBotBase):
 
 async def teardown(bot: tbb.TravusBotBase):
     """Teardown function ran when module is unloaded."""
+    core_cmd_names = ["about", "usage", "module", "default", "config", "command"]
+    # pylint: disable-next=protected-access
+    bot._core_slash_commands = [com for com in bot._core_slash_commands if com.name not in core_cmd_names]
+    # pylint: disable-next=protected-access
+    bot._core_prefix_commands = [com for com in bot._core_prefix_commands if com.name not in core_cmd_names]
     await bot.remove_cog("CoreFunctionalityCog")  # Remove cog and command help info.
     bot.remove_command_help(CoreFunctionalityCog)
 
@@ -77,91 +136,108 @@ class CoreFunctionalityCog(commands.Cog):
         self.log = logging.getLogger("core_commands")
         self.log.setLevel(logging.INFO)
 
-    async def _module_operation(  # pylint: disable=too-many-statements
-        self, ctx: commands.Context, operation: str, mod: str
+    async def _module_operation(  # pylint: disable=too-many-statements,too-many-branches
+        self, invoker: commands.Context | Interaction, operation: str, mod: str
     ):
         """To avoid code duplication in the except blocks all module command functionality is grouped together."""
 
-        async def load():
+        # Abstract over prefix Context vs slash Interaction.
+        if isinstance(invoker, commands.Context):
+
+            async def send(content="", **kwargs):
+                await invoker.send(content, **kwargs)
+
+            user_id = invoker.author.id
+        else:
+
+            async def send(content="", **kwargs):
+                await self.bot.send_response(invoker, content, **kwargs)
+
+            user_id = invoker.user.id
+
+        def clean_text(text: str, escape_md: bool = True, replace_bt: bool = False) -> str:
+            return tbb.clean_no_ctx(self.bot, invoker.guild, text, escape_md, replace_bt)
+
+        async def load() -> str:
             """Contains the logic for loading a module."""
             if f"{mod}.py" in listdir("modules"):
                 await self.bot.load_extension(f"modules.{mod}")
                 await self.bot.update_command_states()
-                await ctx.send(f"Module `{mod_name}` successfully loaded.")
-                self.log.info(f"{ctx.author.id}: loaded '{mod}' module.")
-            else:
-                await ctx.send(f"No `{mod_name}` module was found.")
+                self.log.info(f"{user_id}: loaded '{mod}' module.")
+                return f"Module `{mod_name}` successfully loaded."
+            return f"No `{mod_name}` module was found."
 
-        async def unload():
+        async def unload() -> str:
             """Contains the logic for unloading a module."""
             await self.bot.unload_extension(f"modules.{mod}")
-            await ctx.send(f"Module `{mod_name}` successfully unloaded.")
-            self.log.info(f"{ctx.author.id}: unloaded '{mod}' module.")
+            self.log.info(f"{user_id}: unloaded '{mod}' module.")
+            return f"Module `{mod_name}` successfully unloaded."
 
-        async def reload():
+        async def reload() -> str:
             """Contains the logic for reloading a module."""
             if f"{mod}.py" in listdir("modules"):
                 await self.bot.reload_extension(f"modules.{mod}")
                 await self.bot.update_command_states()
-                await ctx.send(f"Module `{mod_name}` successfully reloaded.")
-                self.log.info(f"{ctx.author.id}: reloaded '{mod}' module.")
-            else:
-                if mod in self.bot.modules:
-                    await ctx.send(f"The `{mod_name}` module file is no longer found on disk. Reload canceled.")
-                else:
-                    await ctx.send(f"No `{mod_name}` module was found.")
+                self.log.info(f"{user_id}: reloaded '{mod}' module.")
+                return f"Module `{mod_name}` successfully reloaded."
+            if mod in self.bot.modules:
+                return f"The `{mod_name}` module file is no longer found on disk. Reload canceled."
+            return f"No `{mod_name}` module was found."
 
         old_help = dict(self.bot.help)  # Save old help and module info in case we need to roll back.
         old_modules = dict(self.bot.modules)
         old_tree_commands = self.bot.tree.get_commands()  # Save tree state for sync rollback.
-        self.bot.extension_ctx = ctx  # Save context in case loaded module has use for it.
-        mod_name = clean(ctx, mod, False, True)
+        self.bot.extension_ctx = invoker  # Save context/interaction in case loaded module has use for it.
+        mod_name = clean_text(mod, False, True)
+        result = ""
         try:
             if operation == "load":
-                await load()
+                result = await load()
             elif operation == "unload":
-                await unload()
+                result = await unload()
             elif operation == "reload":
-                await reload()
+                result = await reload()
         except commands.ExtensionAlreadyLoaded:  # If module was already loaded.
-            await ctx.send(f"The `{mod_name}` module was already loaded.")
+            await send(f"The `{mod_name}` module was already loaded.")
         except commands.ExtensionNotLoaded:  # If module wasn't loaded to begin with.
-            await ctx.send(f"No `{mod_name}` module is loaded.")
+            await send(f"No `{mod_name}` module is loaded.")
         except commands.ExtensionFailed as e:
             self.bot.help = old_help
             self.bot.modules = old_modules
             if isinstance(e.original, tbb.DependencyError):
-                missing_deps = [f"`{clean(ctx, elem, False, True)}`" for elem in e.original.missing_dependencies]
-                await ctx.send(f"Module `{mod_name}` requires these missing dependencies: {', '.join(missing_deps)}")
+                missing_deps = [f"`{clean_text(elem, False, True)}`" for elem in e.original.missing_dependencies]
+                await send(f"Module `{mod_name}` requires these missing dependencies: {', '.join(missing_deps)}")
             else:
-                await ctx.send(
+                await send(
                     "**Error! Something went really wrong! Contact module maintainer.**\nError logged to console and "
                     "stored in module error command."
                 )
-            self.log.error(f"{ctx.author.id}: tried loading '{mod}' module, and it failed:\n\n{e}")
+            self.log.error(f"{user_id}: tried loading '{mod}' module, and it failed:\n\n{e}")
             self.bot.last_module_error = (
-                f"The `{clean(ctx, mod, False)}` module failed while loading. The error was:\n\n{clean(ctx, str(e))}"
+                f"The `{clean_text(mod, False)}` module failed while loading. The error was:\n\n{clean_text(str(e))}"
             )
         except Exception as e:
             self.bot.help = old_help
             self.bot.modules = old_modules
-            await ctx.send(
+            await send(
                 "**Error! Something went really wrong! Contact module maintainer.**\nError logged to console and "
                 "stored in module error command."
             )
             if isinstance(e, commands.ExtensionNotFound):  # Clarify error further in case it was an import error.
                 e = e.__cause__
-            self.log.error(f"{ctx.author.id}: tried loading '{mod}' module, and it failed:\n\n{e!s}")
+            self.log.error(f"{user_id}: tried loading '{mod}' module, and it failed:\n\n{e!s}")
             self.bot.last_module_error = (
-                f"The `{clean(ctx, mod, False)}` module failed while loading. The error was:\n\n{clean(ctx, str(e))}"
+                f"The `{clean_text(mod, False)}` module failed while loading. The error was:\n\n{clean_text(str(e))}"
             )
         else:
             try:
                 await self.bot._apply_core_commands_mode(sync=False)  # pylint: disable=protected-access
                 if {id(com) for com in self.bot.tree.get_commands()} != {id(com) for com in old_tree_commands}:
-                    await ctx.send("Syncing slash command tree, this may take a moment...")
+                    await send(f"{result}\nSyncing slash command tree, this may take a moment...")
                     await self.bot.tree.sync()
-                    await ctx.send("Slash command tree synced.")
+                    await send("Slash command tree synced.")
+                else:
+                    await send(result)
             except Exception as sync_error:  # Sync failed — rollback local state.
                 self.bot.help = old_help
                 self.bot.modules = old_modules
@@ -171,7 +247,7 @@ class CoreFunctionalityCog(commands.Cog):
                 error_msg = f"Tree sync failed after {operation} of '{mod}': {sync_error}"
                 self.log.error(error_msg)
                 self.bot.last_module_error = error_msg
-                await ctx.send(
+                await send(
                     "Module operation succeeded but slash command sync failed. Changes have been rolled back.\n"
                     "Error stored in module lasterror command."
                 )
@@ -485,10 +561,11 @@ class CoreFunctionalityCog(commands.Cog):
         invoke_without_command=True, name="command", aliases=["commands"], usage="<enable/disable/show/hide>"
     )
     async def command(self, ctx: commands.Context):
-        """This command disables, enables, hides and shows other commands. Hiding commands means they don't show up in
-        the overall help command list. Disabling a command means it can't be used. Disabled commands also do not show
-        up in the overall help command list and the specific help text for the command will not be viewable. Core
-        commands cannot be disabled. These settings are saved across restarts."""
+        """This command disables, enables, hides and shows prefix commands. Hiding commands means they don't show up
+        in the overall help command list. Disabling a command means it can't be used. Disabled commands also do not
+        show up in the overall help command list and the specific help text for the command will not be viewable.
+        Core commands cannot be disabled. These settings are saved across restarts. Slash command visibility is
+        managed through Discord's integrations panel in server settings."""
         assert ctx.command is not None
         raise commands.BadArgument(f"No subcommand given for {ctx.command.name}.")
 
@@ -514,9 +591,9 @@ class CoreFunctionalityCog(commands.Cog):
     @commands.has_permissions(administrator=True)
     @command.command(name="enable", usage="<COMMAND NAME>")
     async def command_enable(self, ctx: commands.Context, *, command_name: str):
-        """This command enables commands which have previously been disabled. This will allow them to be used again.
-        It will also add the command back into the list of commands shown by the help command and re-enable the
-        viewing of it's help text given the command has help text, and it has not otherwise been hidden."""
+        """This command enables prefix commands which have previously been disabled. This will allow them to be used
+        again. It will also add the command back into the list of commands shown by the help command and re-enable
+        the viewing of its help text given the command has help text, and it has not otherwise been hidden."""
         if command_name in self.bot.all_commands:  # Check if command exists and get it's state.
             state = await self._command_get_state(self.bot.all_commands[command_name])
             if self.bot.all_commands[command_name].enabled:  # If command is already enabled, report back.
@@ -531,7 +608,7 @@ class CoreFunctionalityCog(commands.Cog):
     @commands.has_permissions(administrator=True)
     @command.command(name="disable", usage="<COMMAND NAME>")
     async def command_disable(self, ctx: commands.Context, *, command_name: str):
-        """This command can disable other commands. Disabled commands cannot be used and are removed from the
+        """This command can disable prefix commands. Disabled commands cannot be used and are removed from the
         list of commands shown by the help command. The command's help text will also not be viewable. Core
         commands cannot be disabled. Disabled commands can be re-enabled with the `command enable` command."""
         if command_name in self.bot.all_commands:  # Check if command exists and get it's state.
@@ -551,7 +628,7 @@ class CoreFunctionalityCog(commands.Cog):
     @commands.has_permissions(administrator=True)
     @command.command(name="show", usage="<COMMAND NAME>")
     async def command_show(self, ctx: commands.Context, *, command_name: str):
-        """This command will show commands which have previously been hidden, reversing the hiding of the
+        """This command will show prefix commands which have previously been hidden, reversing the hiding of the
         command. This will add the command back into the list of commands shown by the help command. This
         will not re-enable the command if it has been disabled. Showing disabled commands alone will not
         be enough to re-add them to the help list since disabling them also hides them from the help list.
@@ -570,9 +647,9 @@ class CoreFunctionalityCog(commands.Cog):
     @commands.has_permissions(administrator=True)
     @command.command(name="hide", usage="<COMMAND NAME>")
     async def command_hide(self, ctx: commands.Context, *, command_name: str):
-        """This command will hide commands from the list of commands shown by the help command. It will
-        not disable the viewing of the help text for the command if someone already knows it's name.
-        Commands who have been hidden can be un-hidden with the `command show` command."""
+        """This command will hide prefix commands from the list of commands shown by the help command. It will
+        not disable the viewing of the help text for the command if someone already knows its name.
+        Commands which have been hidden can be un-hidden with the `command show` command."""
         if command_name in self.bot.all_commands:  # Check if command exists and get it's state.
             state = await self._command_get_state(self.bot.all_commands[command_name])
             if self.bot.all_commands[command_name].hidden:  # Check if command is already hidden.
@@ -592,12 +669,14 @@ class CoreFunctionalityCog(commands.Cog):
         assert self.bot.user is not None
         if module_name is None:  # If no value is passed along we display the about page for the bot itself.
             if self.bot.user.name.lower() in self.bot.modules:  # Check if the bot has an entry.
-                embed = self.bot.modules[self.bot.user.name.lower()].make_about_embed(ctx)  # Make and send response.
+                embed = self.bot.modules[self.bot.user.name.lower()].make_about_embed(
+                    ctx.author
+                )  # Make and send response.
                 await ctx.send(embed=embed)
             else:
                 raise RuntimeError("Bot info module not found.")
         elif module_name.lower() in self.bot.modules:  # Check if the passed along value has an entry.
-            embed = self.bot.modules[module_name.lower()].make_about_embed(ctx)  # Make and send response.
+            embed = self.bot.modules[module_name.lower()].make_about_embed(ctx.author)  # Make and send response.
             await ctx.send(embed=embed)
         else:
             response = f"No information for `{clean(ctx, module_name)}` module was found."
@@ -662,13 +741,11 @@ class CoreFunctionalityCog(commands.Cog):
         raise commands.BadArgument(f"No subcommand given for {ctx.command.name}.")
 
     @commands.has_permissions(administrator=True)
-    @config.command(name="get", usage="<CONFIG_OPTION/all>")
-    async def config_get(self, ctx: commands.Context, option: str):
+    @config.command(name="get", usage="(CONFIG_OPTION)")
+    async def config_get(self, ctx: commands.Context, option: str | None = None):
         """This command is used to get the value of config options. Using this, one can check what configuration
-        options are set to. Using the keyword `all` instead of an option name will print all options and their
-        values."""
-        option = option.lower()
-        if option == "all":
+        options are set to. If no option is given, all options and their values are shown."""
+        if option is None or option.lower() == "all":
             if not self.bot.config:
                 await ctx.send("No configuration options are set.")
                 return
@@ -751,3 +828,488 @@ class CoreFunctionalityCog(commands.Cog):
                     await ctx.send("The time could not be parsed correctly.")
                     self.log.error(f"{ctx.author.id}: {e!s}")
                     self.bot.last_error = f"{ctx.author.id}: {e!s}"
+
+    @app_commands.command(name="about", description="Shows information about the bot or a module.")
+    @app_commands.describe(module_name="Module to show info for, or omit for bot info.")
+    async def slash_about(self, interaction: Interaction, module_name: str | None = None):
+        """This command gives information about modules, such as a description, authors, and other credits. Module
+        authors can even add a small image to be displayed alongside this info. If no module name is given or the
+        bot's name is used then information about the bot itself is shown."""
+        assert self.bot.user is not None
+        if module_name is None:
+            if self.bot.user.name.lower() in self.bot.modules:
+                embed = self.bot.modules[self.bot.user.name.lower()].make_about_embed(interaction.user)
+                await self.bot.send_response(interaction, embed=embed)
+            else:
+                raise RuntimeError("Bot info module not found.")
+        elif module_name.lower() in self.bot.modules:
+            embed = self.bot.modules[module_name.lower()].make_about_embed(interaction.user)
+            await self.bot.send_response(interaction, embed=embed)
+        else:
+            mod = tbb.clean_no_ctx(self.bot, interaction.guild, module_name, False, True)
+            response = f"No information for `{mod}` module was found."
+            if module_name not in [ext.replace("modules.", "") for ext in self.bot.extensions]:
+                response += "\nAdditionally no module with this name is loaded."
+            await self.bot.send_response(interaction, response)
+
+    @slash_about.autocomplete("module_name")
+    async def slash_about_autocomplete(self, _interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
+        """Autocomplete for module_name parameter of /about."""
+        return [
+            app_commands.Choice(name=name, value=name) for name in self.bot.modules if current.lower() in name.lower()
+        ][:25]
+
+    @app_commands.command(name="usage", description="Explains how to use the bot or a module.")
+    @app_commands.describe(module_name="Module to show usage info for, or omit for general bot usage.")
+    async def slash_usage(self, interaction: Interaction, module_name: str | None = None):
+        """This command explains how a module is intended to be used. If no module name is given it will
+        show some basic information about usage of the bot itself."""
+        assert self.bot.user is not None
+        if module_name is None or module_name.lower() in [self.bot.user.name.lower(), "core_commands", "core commands"]:
+            response = (
+                "**How To Use:**\nThis bot features a variety of commands available as slash commands. "
+                "Type `/` in the chat bar to see all available slash commands. For a list of all commands "
+                "you have access to, use the `/help` command. For more information on individual commands, "
+                "run `/help` followed by the command name. This will give you info on the command and any "
+                "examples of it. You might not have access to all commands everywhere, the help command will "
+                "only tell you about commands you have access to in that channel, and commands you can run "
+                "only in the DMs with the bot. DM only commands will be labeled as such by the help command."
+                "\n\nSome commands accept extra input, an example would be how the help command accepts a "
+                "command name. The slash command interface will show you what each argument expects. This is "
+                "how to read the argument descriptions shown by this bot:\n\nArguments encased in `<>` are "
+                "obligatory.\nArguments encased in `()` are optional and can be skipped.\nArguments written "
+                "in all uppercase are placeholders like names.\nArguments not written in uppercase are exact "
+                "values.\nIf an argument lists multiple things separated by `/` then any one of them is valid."
+                "\nThe `<>` and `()` symbols are not part of the command.\n\nSample expected input: "
+                "`/about (MODULE NAME)`\nHere `/about` is the command, and it takes an optional argument. "
+                "The argument is written in all uppercase, so it is a placeholder. In other words you are "
+                "expected to replace 'MODULE NAME' with the actual name of a module. Since the module name "
+                "is optional, sending just `/about` is also a valid command."
+            )
+            await self.bot.send_response(interaction, response)
+        elif module_name.lower() in self.bot.modules:
+            mod_usage = self.bot.modules[module_name.lower()].usage
+            if mod_usage is None:
+                mod = tbb.clean_no_ctx(self.bot, interaction.guild, module_name, False, True)
+                await self.bot.send_response(interaction, f"The `{mod}` module does not have its usage defined.")
+            else:
+                usage_content = mod_usage()
+                if isinstance(usage_content, str):
+                    await self.bot.send_response(
+                        interaction, usage_content if len(usage_content) < 1950 else f"{usage_content[:1949]}..."
+                    )
+                elif isinstance(usage_content, Embed):
+                    await self.bot.send_response(interaction, embed=usage_content)
+        else:
+            mod = tbb.clean_no_ctx(self.bot, interaction.guild, module_name, False, True)
+            response = f"No information for `{mod}` module was found."
+            if module_name not in [ext.replace("modules.", "") for ext in self.bot.extensions]:
+                response += "\nAdditionally no module with this name is loaded."
+            await self.bot.send_response(interaction, response)
+
+    @slash_usage.autocomplete("module_name")
+    async def slash_usage_autocomplete(self, _interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
+        """Autocomplete for module_name parameter of /usage."""
+        return [
+            app_commands.Choice(name=name, value=name) for name in self.bot.modules if current.lower() in name.lower()
+        ][:25]
+
+    slash_module = app_commands.Group(
+        name="module",
+        description="Load, unload, reload, and list bot modules.",
+        guild_only=True,
+        default_permissions=discord.Permissions(administrator=True),
+    )
+
+    @slash_module.command(name="list", description="Lists loaded and available modules.")
+    async def slash_module_list(self, interaction: Interaction):
+        """This command lists all currently loaded and available modules. For the bot to find new modules they need to
+        be placed inside the modules folder inside the bot directory. Modules listed by this command can be loaded,
+        unloaded and reloaded by the respective commands for this."""
+        assert interaction.guild is not None
+        loaded_modules = [
+            f"`{tbb.clean_no_ctx(self.bot, interaction.guild, mod.replace('modules.', ''), False, True)}`, "
+            for mod in self.bot.extensions
+            if mod != "core_commands"
+        ] or ["None, "]
+        available_modules = [
+            f"`{tbb.clean_no_ctx(self.bot, interaction.guild, mod, False, True).replace('.py', '')}`, "
+            for mod in listdir("modules")
+            if mod.endswith(".py")
+        ]
+        available_modules = [mod for mod in available_modules if mod not in loaded_modules] or ["None, "]
+        loaded_modules[-1] = loaded_modules[-1][:-2]
+        available_modules[-1] = available_modules[-1][:-2]
+        paginator = commands.Paginator(prefix="", suffix="", linesep="")
+        paginator.add_line("Loaded modules: ")
+        for mod in loaded_modules:
+            paginator.add_line(mod)
+        paginator.add_line("\nAvailable Modules: ")
+        for mod in available_modules:
+            paginator.add_line(mod)
+        for page in paginator.pages:
+            await self.bot.send_response(interaction, page)
+
+    @slash_module.command(name="load", description="Loads a module.")
+    @app_commands.describe(module="Name of the module to load.")
+    async def slash_module_load(self, interaction: Interaction, module: str):
+        """This command loads modules. Modules should be located inside the module folder in the bot directory. The
+        `/module list` command can be used to show all modules available for loading. Once a module is loaded the
+        functionality defined in the module file will be added to the bot."""
+        await interaction.response.defer(ephemeral=self.bot.ephemeral)
+        await self._module_operation(interaction, "load", module)
+
+    @slash_module.command(name="unload", description="Unloads a module.")
+    @app_commands.describe(module="Name of the module to unload.")
+    async def slash_module_unload(self, interaction: Interaction, module: str):
+        """This command unloads modules. When a loaded module is unloaded its functionality will be removed. You can
+        use the `/module list` command to see all currently loaded modules."""
+        await interaction.response.defer(ephemeral=self.bot.ephemeral)
+        await self._module_operation(interaction, "unload", module)
+
+    @slash_module.command(name="reload", description="Reloads a module.")
+    @app_commands.describe(module="Name of the module to reload.")
+    async def slash_module_reload(self, interaction: Interaction, module: str):
+        """This command reloads a module that is currently loaded. This will unload and load the module in one command.
+        If the loading process encounters an error the module will not be reloaded and the functionality from before
+        the reload will be retained."""
+        await interaction.response.defer(ephemeral=self.bot.ephemeral)
+        await self._module_operation(interaction, "reload", module)
+
+    @slash_module.command(name="lasterror", description="Shows the last module loading error.")
+    async def slash_module_lasterror(self, interaction: Interaction):
+        """This command will show the last error that was encountered during the module load or reloading process. This
+        information will also be logged to the console when the error first is encountered. This command retains this
+        information until another error replaces it, or the bot shuts down."""
+        if self.bot.last_module_error:
+            await self.bot.send_response(interaction, self.bot.last_module_error[:1999])
+        else:
+            await self.bot.send_response(
+                interaction, "There have not been any errors loading modules since the last restart."
+            )
+
+    @slash_module_load.autocomplete("module")
+    async def slash_module_load_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /module load — shows available (not yet loaded) modules."""
+        loaded = {mod.replace("modules.", "") for mod in self.bot.extensions if mod != "core_commands"}
+        available = [
+            mod.replace(".py", "")
+            for mod in listdir("modules")
+            if mod.endswith(".py") and mod.replace(".py", "") not in loaded
+        ]
+        return [app_commands.Choice(name=name, value=name) for name in available if current.lower() in name.lower()][
+            :25
+        ]
+
+    @slash_module_unload.autocomplete("module")
+    async def slash_module_unload_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /module unload — shows loaded modules."""
+        loaded = [mod.replace("modules.", "") for mod in self.bot.extensions if mod != "core_commands"]
+        return [app_commands.Choice(name=name, value=name) for name in loaded if current.lower() in name.lower()][:25]
+
+    @slash_module_reload.autocomplete("module")
+    async def slash_module_reload_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /module reload — shows loaded modules."""
+        loaded = [mod.replace("modules.", "") for mod in self.bot.extensions if mod != "core_commands"]
+        return [app_commands.Choice(name=name, value=name) for name in loaded if current.lower() in name.lower()][:25]
+
+    slash_default = app_commands.Group(
+        name="default",
+        description="Manage default modules that load on startup.",
+        guild_only=True,
+        default_permissions=discord.Permissions(administrator=True),
+    )
+
+    @slash_default.command(name="list", description="Lists all default modules.")
+    async def slash_default_list(self, interaction: Interaction):
+        """This command lists all current default modules. All modules in this list start as soon as the bot is
+        launched. For a list of all available or loaded modules see the `/module list` command."""
+        async with self.bot.db.acquire() as conn:
+            result = await conn.fetch("SELECT module FROM default_modules")
+        entries = [
+            f"`{tbb.clean_no_ctx(self.bot, interaction.guild, val['module'], False, True)}`, " for val in result
+        ] or ["None, "]
+        entries[-1] = entries[-1][:-2]
+        paginator = commands.Paginator(prefix="", suffix="", linesep="")
+        paginator.add_line("Default modules: ")
+        for mod in entries:
+            paginator.add_line(mod)
+        for page in paginator.pages:
+            await self.bot.send_response(interaction, page)
+
+    @slash_default.command(name="add", description="Adds a module to the default list.")
+    @app_commands.describe(module="Name of the module to add as default.")
+    async def slash_default_add(self, interaction: Interaction, module: str):
+        """This command adds a module to the list of default modules. Modules in this list are loaded automatically
+        once the bot starts. This command does not load modules if they are not already loaded."""
+        if f"{module}.py" in listdir("modules"):
+            try:
+                async with self.bot.db.acquire() as conn:
+                    await conn.execute("INSERT INTO default_modules VALUES ($1)", module)
+                    mod = tbb.clean_no_ctx(self.bot, interaction.guild, module, False, True)
+                    await self.bot.send_response(interaction, f"The `{mod}` module is now a default module.")
+            except IntegrityConstraintViolationError:
+                mod = tbb.clean_no_ctx(self.bot, interaction.guild, module, False, True)
+                await self.bot.send_response(interaction, f"The `{mod}` module is already a default module.")
+        else:
+            mod = tbb.clean_no_ctx(self.bot, interaction.guild, module, False, True)
+            await self.bot.send_response(interaction, f"No `{mod}` module was found.")
+
+    @slash_default.command(name="remove", description="Removes a module from the default list.")
+    @app_commands.describe(module="Name of the module to remove from defaults.")
+    async def slash_default_remove(self, interaction: Interaction, module: str):
+        """This command removes a module from the list of default modules. Once removed the module will no longer
+        automatically be loaded when the bot starts. This will not unload modules that are already loaded."""
+        async with self.bot.db.acquire() as conn:
+            result = await conn.fetchval("SELECT module FROM default_modules WHERE module = $1", module)
+            mod = tbb.clean_no_ctx(self.bot, interaction.guild, module, False, True)
+            if result:
+                await conn.execute("DELETE FROM default_modules WHERE module = $1", module)
+                await self.bot.send_response(interaction, f"Removed `{mod}` module from default modules.")
+            else:
+                await self.bot.send_response(interaction, f"No `{mod}` module in default modules.")
+
+    @slash_default_add.autocomplete("module")
+    async def slash_default_add_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /default add — shows available modules on disk."""
+        available = [mod.replace(".py", "") for mod in listdir("modules") if mod.endswith(".py")]
+        return [app_commands.Choice(name=name, value=name) for name in available if current.lower() in name.lower()][
+            :25
+        ]
+
+    @slash_default_remove.autocomplete("module")
+    async def slash_default_remove_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /default remove — shows current default modules."""
+        async with self.bot.db.acquire() as conn:
+            result = await conn.fetch("SELECT module FROM default_modules")
+        defaults = [val["module"] for val in result]
+        return [app_commands.Choice(name=name, value=name) for name in defaults if current.lower() in name.lower()][:25]
+
+    slash_config = app_commands.Group(
+        name="config",
+        description="Get, set, or unset bot configuration options.",
+        guild_only=True,
+        default_permissions=discord.Permissions(administrator=True),
+    )
+
+    @slash_config.command(name="get", description="Shows the value of a config option, or all options.")
+    @app_commands.describe(option="Config option to look up, or omit to show all.")
+    async def slash_config_get(self, interaction: Interaction, option: str | None = None):
+        """This command shows the value of a configuration option. If no option is given, all configuration
+        options and their values are shown."""
+        if option is None or option.lower() == "all":
+            if not self.bot.config:
+                await self.bot.send_response(interaction, "No configuration options are set.")
+                return
+            paginator = commands.Paginator()
+            for line in [f"{key}: {value}" for key, value in self.bot.config.items()]:
+                line = tbb.clean_no_ctx(self.bot, interaction.guild, line, False, True)
+                paginator.add_line(line if len(line) < 1992 else f"{line[:1989]}...")
+            for page in paginator.pages:
+                await self.bot.send_response(interaction, page)
+        elif option.lower() in self.bot.config:
+            value = tbb.clean_no_ctx(self.bot, interaction.guild, self.bot.config[option.lower()], False, True)
+            opt = tbb.clean_no_ctx(self.bot, interaction.guild, option.lower(), False, True)
+            line = f"Option: `{opt}`, value: `{value}`"
+            await self.bot.send_response(interaction, line if len(line) < 1994 else f"{line[:1991]}...")
+        else:
+            opt = tbb.clean_no_ctx(self.bot, interaction.guild, option, False, True)
+            await self.bot.send_response(
+                interaction, f"No configuration option `{opt if len(opt) < 1960 else opt[:1959]}...` is set."
+            )
+
+    @slash_config.command(name="set", description="Sets a configuration option.")
+    @app_commands.describe(option="Configuration option name.", value="Value to set.")
+    async def slash_config_set(self, interaction: Interaction, option: str, value: str):
+        """This command sets a configuration option used by other modules or commands. Setting an existing option
+        overwrites it. The keyword 'all' cannot be used as an option name."""
+        option = option.lower()
+        if option == "all":
+            await self.bot.send_response(interaction, "The keyword `all` cannot be used as a configuration option.")
+        else:
+            self.bot.config[option] = value
+            async with self.bot.db.acquire() as conn:
+                await conn.execute(
+                    "INSERT INTO config VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = $2", option, value
+                )
+            opt = tbb.clean_no_ctx(self.bot, interaction.guild, option, False, True)
+            val = tbb.clean_no_ctx(self.bot, interaction.guild, value, False, True)
+            line = f"Configuration option `{opt}` has been set to `{val}`."
+            await self.bot.send_response(interaction, line if len(line) < 2000 else f"{line[:1996]}...")
+
+    @slash_config.command(name="unset", description="Removes a configuration option.")
+    @app_commands.describe(option="Configuration option to remove.")
+    async def slash_config_unset(self, interaction: Interaction, option: str):
+        """This command removes a configuration option. Removing options required by commands or modules will stop
+        those from working."""
+        option = option.lower()
+        if option in self.bot.config:
+            del self.bot.config[option]
+            async with self.bot.db.acquire() as conn:
+                await conn.execute("DELETE FROM config WHERE key = $1", option)
+            opt = tbb.clean_no_ctx(self.bot, interaction.guild, option, False, True)
+            line = f"Configuration option `{opt}` has been unset."
+            await self.bot.send_response(interaction, line if len(line) < 2000 else f"{line[:1996]}...")
+        else:
+            opt = tbb.clean_no_ctx(self.bot, interaction.guild, option, False, True)
+            line = f"No configuration option `{opt}` exists."
+            await self.bot.send_response(interaction, line if len(line) < 2000 else f"{line[:1996]}...")
+
+    @slash_config_get.autocomplete("option")
+    async def slash_config_get_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /config get — shows existing config keys and 'all'."""
+        keys = ["all", *self.bot.config]
+        return [app_commands.Choice(name=key, value=key) for key in keys if current.lower() in key.lower()][:25]
+
+    @slash_config_set.autocomplete("option")
+    async def slash_config_set_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /config set — shows existing config keys."""
+        return [app_commands.Choice(name=key, value=key) for key in self.bot.config if current.lower() in key.lower()][
+            :25
+        ]
+
+    @slash_config_unset.autocomplete("option")
+    async def slash_config_unset_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /config unset — shows existing config keys."""
+        return [app_commands.Choice(name=key, value=key) for key in self.bot.config if current.lower() in key.lower()][
+            :25
+        ]
+
+    slash_command = app_commands.Group(
+        name="command",
+        description="Enable, disable, show, or hide prefix commands.",
+        guild_only=True,
+        default_permissions=discord.Permissions(administrator=True),
+    )
+
+    @slash_command.command(name="enable", description="Enables a previously disabled prefix command.")
+    @app_commands.describe(command_name="Name of the prefix command to enable.")
+    async def slash_command_enable(self, interaction: Interaction, command_name: str):
+        """This command enables prefix commands which have previously been disabled. This will allow them to be used
+        again. It will also add the command back into the list of commands shown by the help command and re-enable
+        the viewing of its help text given the command has help text, and it has not otherwise been hidden."""
+        if command_name in self.bot.all_commands:
+            state = await self._command_get_state(self.bot.all_commands[command_name])
+            if self.bot.all_commands[command_name].enabled:
+                name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+                await self.bot.send_response(interaction, f"The `{name}` command is already enabled.")
+            else:
+                self.bot.all_commands[command_name].enabled = True
+                await self._command_set_state(self.bot.all_commands[command_name], 0 if state == 2 else 1)
+                name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+                await self.bot.send_response(interaction, f"The `{name}` command is now enabled.")
+        else:
+            name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+            await self.bot.send_response(interaction, f"No `{name}` command found.")
+
+    @slash_command.command(name="disable", description="Disables a prefix command.")
+    @app_commands.describe(command_name="Name of the prefix command to disable.")
+    async def slash_command_disable(self, interaction: Interaction, command_name: str):
+        """This command can disable prefix commands. Disabled commands cannot be used and are removed from the
+        list of commands shown by the help command. The command's help text will also not be viewable. Core
+        commands cannot be disabled. Disabled commands can be re-enabled with the `/command enable` command."""
+        if command_name in self.bot.all_commands:
+            state = await self._command_get_state(self.bot.all_commands[command_name])
+            if command_name in self.bot.help and self.bot.help[command_name].category.lower() == "core":
+                await self.bot.send_response(interaction, "Core commands cannot be disabled.")
+            else:
+                if not self.bot.all_commands[command_name].enabled:
+                    name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+                    await self.bot.send_response(interaction, f"The `{name}` command is already disabled.")
+                else:
+                    self.bot.all_commands[command_name].enabled = False
+                    await self._command_set_state(self.bot.all_commands[command_name], 2 if state == 0 else 3)
+                    name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+                    await self.bot.send_response(interaction, f"The `{name}` command is now disabled.")
+        else:
+            name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+            await self.bot.send_response(interaction, f"No `{name}` command found.")
+
+    @slash_command.command(name="show", description="Shows a previously hidden prefix command.")
+    @app_commands.describe(command_name="Name of the prefix command to show.")
+    async def slash_command_show(self, interaction: Interaction, command_name: str):
+        """This command will show prefix commands which have previously been hidden, reversing the hiding of the
+        command. This will add the command back into the list of commands shown by the help command. This
+        will not re-enable the command if it has been disabled."""
+        if command_name in self.bot.all_commands:
+            state = await self._command_get_state(self.bot.all_commands[command_name])
+            if not self.bot.all_commands[command_name].hidden:
+                name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+                await self.bot.send_response(interaction, f"The `{name}` command is already shown.")
+            else:
+                self.bot.all_commands[command_name].hidden = False
+                await self._command_set_state(self.bot.all_commands[command_name], 0 if state == 1 else 2)
+                name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+                await self.bot.send_response(interaction, f"The `{name}` command is now shown.")
+        else:
+            name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+            await self.bot.send_response(interaction, f"No `{name}` command found.")
+
+    @slash_command.command(name="hide", description="Hides a prefix command from the help list.")
+    @app_commands.describe(command_name="Name of the prefix command to hide.")
+    async def slash_command_hide(self, interaction: Interaction, command_name: str):
+        """This command will hide prefix commands from the list of commands shown by the help command. It will
+        not disable the viewing of the help text for the command if someone already knows its name.
+        Commands which have been hidden can be un-hidden with the `/command show` command."""
+        if command_name in self.bot.all_commands:
+            state = await self._command_get_state(self.bot.all_commands[command_name])
+            if self.bot.all_commands[command_name].hidden:
+                name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+                await self.bot.send_response(interaction, f"The `{name}` command is already hidden.")
+            else:
+                self.bot.all_commands[command_name].hidden = True
+                await self._command_set_state(self.bot.all_commands[command_name], 1 if state == 0 else 3)
+                name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+                await self.bot.send_response(interaction, f"The `{name}` command is now hidden.")
+        else:
+            name = tbb.clean_no_ctx(self.bot, interaction.guild, command_name, False, True)
+            await self.bot.send_response(interaction, f"No `{name}` command found.")
+
+    @slash_command_enable.autocomplete("command_name")
+    async def slash_command_enable_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /command enable — shows disabled commands."""
+        names = sorted({cmd.name for cmd in self.bot.all_commands.values() if not cmd.enabled})
+        return [app_commands.Choice(name=name, value=name) for name in names if current.lower() in name.lower()][:25]
+
+    @slash_command_disable.autocomplete("command_name")
+    async def slash_command_disable_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /command disable — shows enabled non-core commands."""
+        core = {n for n, h in self.bot.help.items() if h.category.lower() == "core"}
+        names = sorted({cmd.name for cmd in self.bot.all_commands.values() if cmd.enabled and cmd.name not in core})
+        return [app_commands.Choice(name=name, value=name) for name in names if current.lower() in name.lower()][:25]
+
+    @slash_command_show.autocomplete("command_name")
+    async def slash_command_show_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /command show — shows hidden commands."""
+        names = sorted({cmd.name for cmd in self.bot.all_commands.values() if cmd.hidden})
+        return [app_commands.Choice(name=name, value=name) for name in names if current.lower() in name.lower()][:25]
+
+    @slash_command_hide.autocomplete("command_name")
+    async def slash_command_hide_autocomplete(
+        self, _interaction: Interaction, current: str
+    ) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /command hide — shows non-hidden commands."""
+        names = sorted({cmd.name for cmd in self.bot.all_commands.values() if not cmd.hidden})
+        return [app_commands.Choice(name=name, value=name) for name in names if current.lower() in name.lower()][:25]

--- a/core_commands.py
+++ b/core_commands.py
@@ -157,7 +157,7 @@ class CoreFunctionalityCog(commands.Cog):
             )
         else:
             try:
-                await self.bot.apply_core_commands_mode(sync=False)
+                await self.bot._apply_core_commands_mode(sync=False)  # pylint: disable=protected-access
                 if {id(com) for com in self.bot.tree.get_commands()} != {id(com) for com in old_tree_commands}:
                     await ctx.send("Syncing slash command tree, this may take a moment...")
                     await self.bot.tree.sync()
@@ -287,7 +287,7 @@ class CoreFunctionalityCog(commands.Cog):
         async with self.bot.db.acquire() as conn:
             await conn.execute("UPDATE settings SET value = $1 WHERE key = 'core_commands_mode'", mode)
         await ctx.send(f"Core commands mode set to `{mode}`.\nSyncing slash command tree, this may take a moment...")
-        await self.bot.apply_core_commands_mode()
+        await self.bot._apply_core_commands_mode()  # pylint: disable=protected-access
         await self.bot.update_status()
         await ctx.send("Slash command tree synced.")
 

--- a/core_commands.py
+++ b/core_commands.py
@@ -4,7 +4,7 @@ from os import listdir  # To check files on disk.
 from typing import Optional
 
 from asyncpg import IntegrityConstraintViolationError  # To check for database conflicts.
-from discord import Activity, ActivityType, Embed  # For bot status
+from discord import Embed
 from discord.ext import commands  # For implementation of bot commands.
 
 import travus_bot_base as tbb  # TBB functions and classes.
@@ -14,12 +14,11 @@ from travus_bot_base import clean  # Shorthand for cleaning output.
 async def setup(bot: tbb.TravusBotBase):
     """Setup function ran when module is loaded."""
     await bot.add_cog(CoreFunctionalityCog(bot))  # Add cog and command help info.
-    bot.add_command_help(CoreFunctionalityCog.botconfig_prefix, "Core", None, ["$", "bot!", "bot ?", "remove"])
-    bot.add_command_help(CoreFunctionalityCog.botconfig_deletemessages, "Core", None, ["enable", "y", "disable", "n"])
     bot.add_command_help(CoreFunctionalityCog.module_list, "Core", {"perms": ["Administrator"]}, [""])
     bot.add_command_help(CoreFunctionalityCog.module_load, "Core", {"perms": ["Administrator"]}, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.module_unload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.module_reload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"])
+    bot.add_command_help(CoreFunctionalityCog.module_lasterror, "Core", {"perms": ["Administrator"]}, [""])
     bot.add_command_help(CoreFunctionalityCog.default, "Core", None, ["list", "add", "remove"])
     bot.add_command_help(CoreFunctionalityCog.default_list, "Core", None, [""])
     bot.add_command_help(CoreFunctionalityCog.default_add, "Core", None, ["fun", "economy"])
@@ -34,8 +33,15 @@ async def setup(bot: tbb.TravusBotBase):
     bot.add_command_help(CoreFunctionalityCog.config_get, "Core", {"perms": ["Administrator"]}, ["alert_channel"])
     bot.add_command_help(CoreFunctionalityCog.config_unset, "Core", {"perms": ["Administrator"]}, ["alert_channel"])
     bot.add_command_help(CoreFunctionalityCog.shutdown, "Core", None, ["", "1h", "1h30m", "10m-30s", "2m30s"])
+    bot.add_command_help(CoreFunctionalityCog.botconfig_prefix, "Core", None, ["$", "bot!", "bot ?", "remove"])
+    bot.add_command_help(CoreFunctionalityCog.botconfig_deletemessages, "Core", None, ["enable", "y", "disable", "n"])
+    bot.add_command_help(CoreFunctionalityCog.botconfig_ephemeral, "Core", None, ["enable", "y", "disable", "n"])
+    bot.add_command_help(CoreFunctionalityCog.botconfig_core_commands, "Core", None, ["slash", "prefix", "both"])
     bot.add_command_help(
-        CoreFunctionalityCog.botconfig, "Core", None, ["prefix", "deletemessages", "description", "credits"]
+        CoreFunctionalityCog.botconfig,
+        "Core",
+        None,
+        ["prefix", "deletemessages", "description", "credits", "ephemeral", "core-commands"],
     )
     bot.add_command_help(
         CoreFunctionalityCog.botconfig_description, "Core", None, ["remove", "This is a sample description."]
@@ -72,7 +78,9 @@ class CoreFunctionalityCog(commands.Cog):
         self.log = logging.getLogger("core_commands")
         self.log.setLevel(logging.INFO)
 
-    async def _module_operation(self, ctx: commands.Context, operation: str, mod: str):
+    async def _module_operation(  # pylint: disable=too-many-statements
+        self, ctx: commands.Context, operation: str, mod: str
+    ):
         """To avoid code duplication in the except blocks all module command functionality is grouped together."""
 
         async def load():
@@ -106,6 +114,7 @@ class CoreFunctionalityCog(commands.Cog):
 
         old_help = dict(self.bot.help)  # Save old help and module info in case we need to roll back.
         old_modules = dict(self.bot.modules)
+        old_tree_commands = self.bot.tree.get_commands()  # Save tree state for sync rollback.
         self.bot.extension_ctx = ctx  # Save context in case loaded module has use for it.
         mod_name = clean(ctx, mod, False, True)
         try:
@@ -147,15 +156,39 @@ class CoreFunctionalityCog(commands.Cog):
             self.bot.last_module_error = (
                 f"The `{clean(ctx, mod, False)}` module failed while loading. The error was:\n\n{clean(ctx, str(e))}"
             )
+        else:
+            try:
+                await self.bot.apply_core_commands_mode(sync=False)
+                if {id(com) for com in self.bot.tree.get_commands()} != {id(com) for com in old_tree_commands}:
+                    await ctx.send("Syncing slash command tree, this may take a moment...")
+                    await self.bot.tree.sync()
+                    await ctx.send("Slash command tree synced.")
+            except Exception as sync_error:  # Sync failed — rollback local state.
+                self.bot.help = old_help
+                self.bot.modules = old_modules
+                self.bot.tree.clear_commands(guild=None)
+                for cmd in old_tree_commands:
+                    self.bot.tree.add_command(cmd)
+                error_msg = f"Tree sync failed after {operation} of '{mod}': {sync_error}"
+                self.log.error(error_msg)
+                self.bot.last_module_error = error_msg
+                await ctx.send(
+                    "Module operation succeeded but slash command sync failed. Changes have been rolled back.\n"
+                    "Error stored in module lasterror command."
+                )
         finally:  # Reset context as loading has concluded.
             self.bot.extension_ctx = None
 
     @commands.is_owner()
-    @commands.group(invoke_without_command=True, name="botconfig", usage="<prefix/deletemessages/description/credits>")
+    @commands.group(
+        invoke_without_command=True,
+        name="botconfig",
+        usage="<prefix/deletemessages/description/credits/ephemeral/core-commands>",
+    )
     async def botconfig(self, ctx: commands.Context):
-        """This command sets the bot's prefix, command trigger deletion behaviour, description and additional credits
-        section. For more information, check the help entry of one of these subcommands; `prefix`, `deletemessages`,
-        `description`, `credits`."""
+        """This command sets the bot's prefix, command trigger deletion behaviour, description, additional credits
+        section, ephemeral response behaviour, and core command mode. For more information, check the help entry of one
+        of these subcommands; `prefix`, `deletemessages`, `description`, `credits`, `ephemeral`, `core-commands`."""
         assert ctx.command is not None
         raise commands.BadArgument(f"No subcommand given for {ctx.command.name}.")
 
@@ -171,11 +204,7 @@ class CoreFunctionalityCog(commands.Cog):
             await ctx.send("The maximum prefix length is 20.")
             return
         self.bot.prefix = new_prefix if new_prefix.lower() != "remove" else None  # If 'remove', prefix is set to None.
-        activity = Activity(
-            type=ActivityType.listening,
-            name=f"prefix: {new_prefix}" if new_prefix.lower() != "remove" else "pings only",
-        )
-        await self.bot.change_presence(activity=activity)  # Set status.
+        await self.bot.update_status()
         async with self.bot.db.acquire() as conn:
             await conn.execute(
                 "UPDATE settings SET value = $1 WHERE key = 'prefix'",
@@ -214,6 +243,54 @@ class CoreFunctionalityCog(commands.Cog):
                 await ctx.send("No longer deleting command triggers.")
             else:
                 raise commands.BadArgument("Operation not supported.")
+
+    @commands.is_owner()
+    @botconfig.command(
+        name="ephemeral",
+        usage="<enable/disable>",
+    )
+    async def botconfig_ephemeral(self, ctx: commands.Context, operation: str):
+        """This command sets whether core slash command responses are ephemeral (only visible to the user who ran the
+        command). If enabled, slash command responses will be ephemeral by default. If disabled, responses will be
+        visible to everyone. Per default this is enabled. This setting is saved across restarts. Module authors can
+        choose to respect this setting for their own slash commands."""
+        async with self.bot.db.acquire() as conn:
+            if operation.lower() in ["enable", "true", "on", "yes", "y", "+", "1"]:
+                if self.bot.ephemeral:
+                    await ctx.send("Ephemeral responses are already enabled.")
+                    return
+                await conn.execute("UPDATE settings SET value = '1' WHERE key = 'ephemeral'")
+                self.bot.ephemeral = True
+                await ctx.send("Slash command responses are now ephemeral.")
+            elif operation.lower() in ["disable", "false", "off", "no", "n", "-", "0"]:
+                if not self.bot.ephemeral:
+                    await ctx.send("Ephemeral responses are already disabled.")
+                    return
+                await conn.execute("UPDATE settings SET value = '0' WHERE key = 'ephemeral'")
+                self.bot.ephemeral = False
+                await ctx.send("Slash command responses are now visible to everyone.")
+            else:
+                raise commands.BadArgument("Operation not supported.")
+
+    @commands.is_owner()
+    @botconfig.command(name="core-commands", aliases=["corecommands", "corecmds"], usage="<slash/prefix/both>")
+    async def botconfig_core_commands(self, ctx: commands.Context, mode: str):
+        """This command sets whether core commands are registered as slash commands, prefix commands, or both. The
+        default is `slash`. The `help` command always exists as both slash and prefix regardless of this setting.
+        The `botconfig` command is always prefix-only. This setting is saved across restarts."""
+        mode = mode.lower()
+        if mode not in ("slash", "prefix", "both"):
+            raise commands.BadArgument("Mode must be `slash`, `prefix`, or `both`.")
+        if mode == self.bot.core_commands_mode:
+            await ctx.send(f"Core commands mode is already set to `{mode}`.")
+            return
+        self.bot.core_commands_mode = mode
+        async with self.bot.db.acquire() as conn:
+            await conn.execute("UPDATE settings SET value = $1 WHERE key = 'core_commands_mode'", mode)
+        await ctx.send(f"Core commands mode set to `{mode}`.\nSyncing slash command tree, this may take a moment...")
+        await self.bot.apply_core_commands_mode()
+        await self.bot.update_status()
+        await ctx.send("Slash command tree synced.")
 
     @commands.is_owner()
     @botconfig.command(name="description", aliases=["desc"], usage="<DESCRIPTION/remove>")
@@ -265,7 +342,7 @@ class CoreFunctionalityCog(commands.Cog):
 
     @commands.has_permissions(administrator=True)
     @commands.group(
-        invoke_without_command=True, name="module", aliases=["modules"], usage="<list/load/unload/reload/error>"
+        invoke_without_command=True, name="module", aliases=["modules"], usage="<list/load/unload/reload/lasterror>"
     )
     async def module(self, ctx: commands.Context):
         """This command can load, unload, reload and list available modules. It can also show any errors that occur
@@ -336,8 +413,8 @@ class CoreFunctionalityCog(commands.Cog):
         await self._module_operation(ctx, "reload", mod)
 
     @commands.has_permissions(administrator=True)
-    @module.command(name="error")
-    async def module_error(self, ctx: commands.Context):
+    @module.command(name="lasterror", aliases=["error", "le"])
+    async def module_lasterror(self, ctx: commands.Context):
         """This command will show the last error that was encountered during the module load or reloading process. This
         information will also be logged to the console when the error first is encountered. This command retains this
         information until another error replaces it, or the bot shuts down."""

--- a/core_commands.py
+++ b/core_commands.py
@@ -1,7 +1,6 @@
 import logging
 from asyncio import sleep as asleep  # For waiting asynchronously.
 from os import listdir  # To check files on disk.
-from typing import Optional
 
 from asyncpg import IntegrityConstraintViolationError  # To check for database conflicts.
 from discord import Embed
@@ -518,7 +517,7 @@ class CoreFunctionalityCog(commands.Cog):
         """This command enables commands which have previously been disabled. This will allow them to be used again.
         It will also add the command back into the list of commands shown by the help command and re-enable the
         viewing of it's help text given the command has help text, and it has not otherwise been hidden."""
-        if command_name in self.bot.all_commands.keys():  # Check if command exists and get it's state.
+        if command_name in self.bot.all_commands:  # Check if command exists and get it's state.
             state = await self._command_get_state(self.bot.all_commands[command_name])
             if self.bot.all_commands[command_name].enabled:  # If command is already enabled, report back.
                 await ctx.send(f"The `{clean(ctx, command_name)}` command is already enabled.")
@@ -535,9 +534,9 @@ class CoreFunctionalityCog(commands.Cog):
         """This command can disable other commands. Disabled commands cannot be used and are removed from the
         list of commands shown by the help command. The command's help text will also not be viewable. Core
         commands cannot be disabled. Disabled commands can be re-enabled with the `command enable` command."""
-        if command_name in self.bot.all_commands.keys():  # Check if command exists and get it's state.
+        if command_name in self.bot.all_commands:  # Check if command exists and get it's state.
             state = await self._command_get_state(self.bot.all_commands[command_name])
-            if command_name in self.bot.help.keys() and self.bot.help[command_name].category.lower() == "core":
+            if command_name in self.bot.help and self.bot.help[command_name].category.lower() == "core":
                 await ctx.send("Core commands cannot be disabled.")
             else:
                 if not self.bot.all_commands[command_name].enabled:  # Check if the command is already disabled.
@@ -557,7 +556,7 @@ class CoreFunctionalityCog(commands.Cog):
         will not re-enable the command if it has been disabled. Showing disabled commands alone will not
         be enough to re-add them to the help list since disabling them also hides them from the help list.
         See the `command enable` command to re-enable disabled commands."""
-        if command_name in self.bot.all_commands.keys():  # Check if command exists and get it's state.
+        if command_name in self.bot.all_commands:  # Check if command exists and get it's state.
             state = await self._command_get_state(self.bot.all_commands[command_name])
             if not self.bot.all_commands[command_name].hidden:  # Check if command i already visible.
                 await ctx.send(f"The `{clean(ctx, command_name)}` command is already shown.")
@@ -574,7 +573,7 @@ class CoreFunctionalityCog(commands.Cog):
         """This command will hide commands from the list of commands shown by the help command. It will
         not disable the viewing of the help text for the command if someone already knows it's name.
         Commands who have been hidden can be un-hidden with the `command show` command."""
-        if command_name in self.bot.all_commands.keys():  # Check if command exists and get it's state.
+        if command_name in self.bot.all_commands:  # Check if command exists and get it's state.
             state = await self._command_get_state(self.bot.all_commands[command_name])
             if self.bot.all_commands[command_name].hidden:  # Check if command is already hidden.
                 await ctx.send(f"The `{clean(ctx, command_name)}` command is already hidden.")
@@ -592,17 +591,17 @@ class CoreFunctionalityCog(commands.Cog):
         bot's name is used then information about the bot itself is shown."""
         assert self.bot.user is not None
         if module_name is None:  # If no value is passed along we display the about page for the bot itself.
-            if self.bot.user.name.lower() in self.bot.modules.keys():  # Check if the bot has an entry.
+            if self.bot.user.name.lower() in self.bot.modules:  # Check if the bot has an entry.
                 embed = self.bot.modules[self.bot.user.name.lower()].make_about_embed(ctx)  # Make and send response.
                 await ctx.send(embed=embed)
             else:
                 raise RuntimeError("Bot info module not found.")
-        elif module_name.lower() in self.bot.modules.keys():  # Check if the passed along value has an entry.
+        elif module_name.lower() in self.bot.modules:  # Check if the passed along value has an entry.
             embed = self.bot.modules[module_name.lower()].make_about_embed(ctx)  # Make and send response.
             await ctx.send(embed=embed)
         else:
             response = f"No information for `{clean(ctx, module_name)}` module was found."
-            if module_name not in [mod.replace("modules.", "") for mod in self.bot.extensions.keys()]:
+            if module_name not in [mod.replace("modules.", "") for mod in self.bot.extensions]:
                 response += "\nAdditionally no module with this name is loaded."
             await ctx.send(response)
 
@@ -637,7 +636,7 @@ class CoreFunctionalityCog(commands.Cog):
                 f"optional, sending just `{pref}about` is also a valid command."
             )
             await ctx.send(response)
-        elif module_name.lower() in self.bot.modules.keys():
+        elif module_name.lower() in self.bot.modules:
             usage = self.bot.modules[module_name.lower()].usage
             if usage is None:
                 await ctx.send(f"The `{clean(ctx, module_name)}` module does not have its usage defined.")
@@ -649,7 +648,7 @@ class CoreFunctionalityCog(commands.Cog):
                     await ctx.send(embed=usage_content)
         else:
             response = f"No information for `{clean(ctx, module_name)}` module was found."
-            if module_name not in [mod.replace("modules.", "") for mod in self.bot.extensions.keys()]:
+            if module_name not in [mod.replace("modules.", "") for mod in self.bot.extensions]:
                 response += "\nAdditionally no module with this name is loaded."
             await ctx.send(response)
 
@@ -729,7 +728,7 @@ class CoreFunctionalityCog(commands.Cog):
 
     @commands.is_owner()
     @commands.command(name="shutdown", aliases=["goodbye", "goodnight"], usage="(TIME BEFORE SHUTDOWN)")
-    async def shutdown(self, ctx: commands.Context, countdown: Optional[str] = None):
+    async def shutdown(self, ctx: commands.Context, countdown: str | None = None):
         """This command turns the bot off. A delay can be set causing the bot to wait before shutting down. The time
         uses a format of numbers followed by units, see examples for details. Times supported are weeks (w), days (d),
         hours (h), minutes (m) and seconds (s), and even negative numbers. For this command the delay must be between

--- a/core_commands.py
+++ b/core_commands.py
@@ -23,49 +23,38 @@ async def setup(bot: tbb.TravusBotBase):
     )
     # pylint: disable-next=protected-access
     bot._core_prefix_commands.extend([cog.about, cog.usage, cog.module, cog.default, cog.config, cog.command])
+    # /help is added to the tree automatically by add_cog. It is NOT in _core_slash_commands,
+    # so _apply_core_commands_mode never removes it — /help is always available regardless of mode.
     bot.add_command_help(CoreFunctionalityCog.module_list, "Core", {"perms": ["Administrator"]}, [""])
     bot.add_command_help(CoreFunctionalityCog.module_load, "Core", {"perms": ["Administrator"]}, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.module_unload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.module_reload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.module_lasterror, "Core", {"perms": ["Administrator"]}, [""])
-    bot.add_command_help(CoreFunctionalityCog.slash_module_list, "Core", {"perms": ["Administrator"]}, [""])
     bot.add_command_help(
-        CoreFunctionalityCog.slash_module_load, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
+        CoreFunctionalityCog.slash_module, "Core", None, ["list", "load", "unload", "reload", "lasterror"]
     )
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_module_unload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
-    )
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_module_reload, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
-    )
-    bot.add_command_help(CoreFunctionalityCog.slash_module_lasterror, "Core", {"perms": ["Administrator"]}, [""])
+    bot.add_command_help(CoreFunctionalityCog.slash_module_list, "Core", None, [""])
+    bot.add_command_help(CoreFunctionalityCog.slash_module_load, "Core", None, ["fun", "economy"])
+    bot.add_command_help(CoreFunctionalityCog.slash_module_unload, "Core", None, ["fun", "economy"])
+    bot.add_command_help(CoreFunctionalityCog.slash_module_reload, "Core", None, ["fun", "economy"])
+    bot.add_command_help(CoreFunctionalityCog.slash_module_lasterror, "Core", None, [""])
     bot.add_command_help(CoreFunctionalityCog.default, "Core", None, ["list", "add", "remove"])
     bot.add_command_help(CoreFunctionalityCog.default_list, "Core", None, [""])
     bot.add_command_help(CoreFunctionalityCog.default_add, "Core", None, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.default_remove, "Core", None, ["fun", "economy"])
-    bot.add_command_help(CoreFunctionalityCog.slash_default_list, "Core", {"perms": ["Administrator"]}, [""])
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_default_add, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
-    )
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_default_remove, "Core", {"perms": ["Administrator"]}, ["fun", "economy"]
-    )
+    bot.add_command_help(CoreFunctionalityCog.slash_default, "Core", None, ["list", "add", "remove"])
+    bot.add_command_help(CoreFunctionalityCog.slash_default_list, "Core", None, [""])
+    bot.add_command_help(CoreFunctionalityCog.slash_default_add, "Core", None, ["fun", "economy"])
+    bot.add_command_help(CoreFunctionalityCog.slash_default_remove, "Core", None, ["fun", "economy"])
     bot.add_command_help(CoreFunctionalityCog.command_enable, "Core", {"perms": ["Administrator"]}, ["balance", "pay"])
     bot.add_command_help(CoreFunctionalityCog.command_disable, "Core", {"perms": ["Administrator"]}, ["balance", "pay"])
     bot.add_command_help(CoreFunctionalityCog.command_show, "Core", {"perms": ["Administrator"]}, ["module", "balance"])
     bot.add_command_help(CoreFunctionalityCog.command_hide, "Core", {"perms": ["Administrator"]}, ["module", "balance"])
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_command_enable, "Core", {"perms": ["Administrator"]}, ["balance", "pay"]
-    )
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_command_disable, "Core", {"perms": ["Administrator"]}, ["balance", "pay"]
-    )
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_command_show, "Core", {"perms": ["Administrator"]}, ["module", "balance"]
-    )
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_command_hide, "Core", {"perms": ["Administrator"]}, ["module", "balance"]
-    )
+    bot.add_command_help(CoreFunctionalityCog.slash_command, "Core", None, ["enable", "disable", "show", "hide"])
+    bot.add_command_help(CoreFunctionalityCog.slash_command_enable, "Core", None, ["balance", "pay"])
+    bot.add_command_help(CoreFunctionalityCog.slash_command_disable, "Core", None, ["balance", "pay"])
+    bot.add_command_help(CoreFunctionalityCog.slash_command_show, "Core", None, ["module", "balance"])
+    bot.add_command_help(CoreFunctionalityCog.slash_command_hide, "Core", None, ["module", "balance"])
     bot.add_command_help(CoreFunctionalityCog.about, "Core", None, ["", "fun"])
     bot.add_command_help(CoreFunctionalityCog.slash_about, "Core", None, ["", "dev"])
     bot.add_command_help(CoreFunctionalityCog.usage, "Core", None, ["", "dev"])
@@ -73,18 +62,10 @@ async def setup(bot: tbb.TravusBotBase):
     bot.add_command_help(CoreFunctionalityCog.config, "Core", {"perms": ["Administrator"]}, ["get", "set", "unset"])
     bot.add_command_help(CoreFunctionalityCog.config_get, "Core", {"perms": ["Administrator"]}, ["", "alert_channel"])
     bot.add_command_help(CoreFunctionalityCog.config_unset, "Core", {"perms": ["Administrator"]}, ["alert_channel"])
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_config_get, "Core", {"perms": ["Administrator"]}, ["", "alert_channel"]
-    )
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_config_set,
-        "Core",
-        {"perms": ["Administrator"]},
-        ["alert_channel 353246496952418305"],
-    )
-    bot.add_command_help(
-        CoreFunctionalityCog.slash_config_unset, "Core", {"perms": ["Administrator"]}, ["alert_channel"]
-    )
+    bot.add_command_help(CoreFunctionalityCog.slash_config, "Core", None, ["get", "set", "unset"])
+    bot.add_command_help(CoreFunctionalityCog.slash_config_get, "Core", None, ["", "alert_channel"])
+    bot.add_command_help(CoreFunctionalityCog.slash_config_set, "Core", None, ["alert_channel 353246496952418305"])
+    bot.add_command_help(CoreFunctionalityCog.slash_config_unset, "Core", None, ["alert_channel"])
     bot.add_command_help(CoreFunctionalityCog.shutdown, "Core", None, ["", "1h", "1h30m", "10m-30s", "2m30s"])
     bot.add_command_help(CoreFunctionalityCog.botconfig_prefix, "Core", None, ["$", "bot!", "bot ?", "remove"])
     bot.add_command_help(CoreFunctionalityCog.botconfig_deletemessages, "Core", None, ["enable", "y", "disable", "n"])
@@ -94,7 +75,7 @@ async def setup(bot: tbb.TravusBotBase):
         CoreFunctionalityCog.botconfig,
         "Core",
         None,
-        ["prefix", "deletemessages", "description", "credits", "ephemeral", "core-commands"],
+        ["prefix", "deletemessages", "description", "credits", "ephemeral", "corecommands"],
     )
     bot.add_command_help(
         CoreFunctionalityCog.botconfig_description, "Core", None, ["remove", "This is a sample description."]
@@ -114,6 +95,7 @@ async def setup(bot: tbb.TravusBotBase):
         None,
         ["remove", "`\n```\n[Person](URL):\n\tBot Profile Image\n``"],
     )
+    bot.add_command_help(CoreFunctionalityCog.slash_help, "Core", None, ["", "about", "module list"])
 
 
 async def teardown(bot: tbb.TravusBotBase):
@@ -123,7 +105,7 @@ async def teardown(bot: tbb.TravusBotBase):
     bot._core_slash_commands = [com for com in bot._core_slash_commands if com.name not in core_cmd_names]
     # pylint: disable-next=protected-access
     bot._core_prefix_commands = [com for com in bot._core_prefix_commands if com.name not in core_cmd_names]
-    await bot.remove_cog("CoreFunctionalityCog")  # Remove cog and command help info.
+    await bot.remove_cog("CoreFunctionalityCog")  # Remove cog, command help info, and /help from tree.
     bot.remove_command_help(CoreFunctionalityCog)
 
 
@@ -258,12 +240,12 @@ class CoreFunctionalityCog(commands.Cog):
     @commands.group(
         invoke_without_command=True,
         name="botconfig",
-        usage="<prefix/deletemessages/description/credits/ephemeral/core-commands>",
+        usage="<prefix/deletemessages/description/credits/ephemeral/corecommands>",
     )
     async def botconfig(self, ctx: commands.Context):
         """This command sets the bot's prefix, command trigger deletion behaviour, description, additional credits
         section, ephemeral response behaviour, and core command mode. For more information, check the help entry of one
-        of these subcommands; `prefix`, `deletemessages`, `description`, `credits`, `ephemeral`, `core-commands`."""
+        of these subcommands; `prefix`, `deletemessages`, `description`, `credits`, `ephemeral`, `corecommands`."""
         assert ctx.command is not None
         raise commands.BadArgument(f"No subcommand given for {ctx.command.name}.")
 
@@ -348,7 +330,7 @@ class CoreFunctionalityCog(commands.Cog):
                 raise commands.BadArgument("Operation not supported.")
 
     @commands.is_owner()
-    @botconfig.command(name="core-commands", aliases=["corecommands", "corecmds"], usage="<slash/prefix/both>")
+    @botconfig.command(name="corecommands", aliases=["core-commands", "corecmds"], usage="<slash/prefix/both>")
     async def botconfig_core_commands(self, ctx: commands.Context, mode: str):
         """This command sets whether core commands are registered as slash commands, prefix commands, or both. The
         default is `slash`. The `help` command always exists as both slash and prefix regardless of this setting.
@@ -920,6 +902,11 @@ class CoreFunctionalityCog(commands.Cog):
         guild_only=True,
         default_permissions=discord.Permissions(administrator=True),
     )
+    slash_module.__doc__ = """This command can load, unload, reload and list available modules. It can also show any
+    errors that occur during the loading process. Modules contain added functionality, such as commands. The intended
+    purpose for modules is to extend the bot's functionality in semi-independent packages so that parts of the bot's
+    functionality can be removed or restarted without affecting the rest of the bot's functionality. See the help text
+    for the subcommands for more info."""
 
     @slash_module.command(name="list", description="Lists loaded and available modules.")
     async def slash_module_list(self, interaction: Interaction):
@@ -1025,6 +1012,10 @@ class CoreFunctionalityCog(commands.Cog):
         guild_only=True,
         default_permissions=discord.Permissions(administrator=True),
     )
+    slash_default.__doc__ = """This command is used to add, remove or list default modules. Modules contain added
+    functionality, such as commands. Default modules are loaded automatically when the bot starts and as such any
+    functionality in them will be available as soon as the bot is online. For more info see the help text of the
+    subcommands."""
 
     @slash_default.command(name="list", description="Lists all default modules.")
     async def slash_default_list(self, interaction: Interaction):
@@ -1101,6 +1092,9 @@ class CoreFunctionalityCog(commands.Cog):
         guild_only=True,
         default_permissions=discord.Permissions(administrator=True),
     )
+    slash_config.__doc__ = """This command is used to get, set and unset configuration options used by other modules
+    or commands. All config options are saved as strings. Converting them to the proper type is up to the module or
+    command that uses them. See the help text for the subcommands for more info."""
 
     @slash_config.command(name="get", description="Shows the value of a config option, or all options.")
     @app_commands.describe(option="Config option to look up, or omit to show all.")
@@ -1197,6 +1191,11 @@ class CoreFunctionalityCog(commands.Cog):
         guild_only=True,
         default_permissions=discord.Permissions(administrator=True),
     )
+    slash_command.__doc__ = """This command disables, enables, hides and shows prefix commands. Hiding commands means
+    they don't show up in the overall help command list. Disabling a command means it can't be used. Disabled commands
+    also do not show up in the overall help command list and the specific help text for the command will not be
+    viewable. Core commands cannot be disabled. These settings are saved across restarts. Slash command visibility is
+    managed through Discord's integrations panel in server settings."""
 
     @slash_command.command(name="enable", description="Enables a previously disabled prefix command.")
     @app_commands.describe(command_name="Name of the prefix command to enable.")
@@ -1312,4 +1311,27 @@ class CoreFunctionalityCog(commands.Cog):
     ) -> list[app_commands.Choice[str]]:
         """Autocomplete for /command hide — shows non-hidden commands."""
         names = sorted({cmd.name for cmd in self.bot.all_commands.values() if not cmd.hidden})
+        return [app_commands.Choice(name=name, value=name) for name in names if current.lower() in name.lower()][:25]
+
+    @app_commands.command(name="help", description="Shows help info for the bot or a specific command.")
+    @app_commands.describe(command="Command to show help for, or omit for the full command list.")
+    async def slash_help(self, interaction: Interaction, command: str | None = None):
+        """This command shows a list of categorized commands you have access to. If the name of a command is sent along
+        it will show detailed help information for that command, such as what the command does, aliases, what
+        restrictions it has, and examples."""
+        ctx = await self.bot.get_context(interaction, cls=tbb.TBBContext)
+        if command:
+            # Direct lookup bypassing discord.py's prefix-only resolution.
+            assert self.bot.help_command is not None
+            help_cmd = self.bot.help_command.copy()
+            help_cmd.context = ctx  # type: ignore[assignment]  # TBBContext is a valid Context.
+            send_help = help_cmd._send_help_entry  # type: ignore  # pylint: disable=protected-access
+            await send_help(command)
+        else:
+            await ctx.send_help()
+
+    @slash_help.autocomplete("command")
+    async def slash_help_autocomplete(self, _interaction: Interaction, current: str) -> list[app_commands.Choice[str]]:
+        """Autocomplete for /help — shows all available help entries."""
+        names = sorted({*self.bot.help, *self.bot.slash_help})
         return [app_commands.Choice(name=name, value=name) for name in names if current.lower() in name.lower()][:25]

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ async def main(logger: logging.Logger):
     if "config.yml" not in os.listdir("."):
         logger.critical("Please run one_time_setup.py first!")
         exit(5)
-    with open("config.yml", "r", encoding="utf8") as config_object:
+    with open("config.yml", encoding="utf8") as config_object:
         config = yaml.safe_load(config_object)
         if not all(element in config and config[element] is not None for element in config_options):
             logger.critical("Config was found, but lacked required options. Please run one_time_setup.py first.")

--- a/modules/dev.py
+++ b/modules/dev.py
@@ -38,8 +38,8 @@ async def setup(bot: tbb.TravusBotBase):
     bot.add_command_help(DevCog.sync, "Dev", None, ["", "guild"])
     bot.add_command_help(DevCog.slash_ping, "Dev", None, [""])
     bot.add_command_help(DevCog.slash_lasterror, "Dev", None, [""])
-    bot.add_command_help(DevCog.slash_roleids, "Dev", None, ["", "@Moderator"])
-    bot.add_command_help(DevCog.slash_channelids, "Dev", None, ["", "#general"])
+    bot.add_command_help(DevCog.slash_roleids, "Dev", None, ["", "@Moderator", "@Moderator #bot-room"])
+    bot.add_command_help(DevCog.slash_channelids, "Dev", None, ["", "#general", "#general #bot-room"])
     bot.add_command_help(
         DevCog.channelids, "Dev", {"perms": ["Manage Channels"]}, ["all bot_room", "all dm", "general"]
     )
@@ -194,21 +194,18 @@ class DevCog(commands.Cog):
         response is sent in that channel. Sending `dm` instead of a second channel will send you the result in direct
         messages."""
         assert ctx.guild is not None
-        response = ""
         paginator = commands.Paginator()
         if isinstance(channel, str) and channel.lower() == "all":
-            for _channel in ctx.guild.text_channels:
-                paginator.add_line(f"{_channel.name}: {_channel.id}")
-            for _channel in ctx.guild.voice_channels:
+            for _channel in ctx.guild.channels:
                 paginator.add_line(f"{_channel.name}: {_channel.id}")
             for page in paginator.pages:
                 await tbb.send_in_global_channel(ctx, resp_channel, page)
         elif isinstance(channel, str):
             raise commands.BadArgument("Channel could not be parsed and string is not 'all'.")
         else:
-            if hasattr(channel, "name") and hasattr(channel, "id"):
-                response = f"{channel.name}: {channel.id}"  # type: ignore[union-attr]
-        await tbb.send_in_global_channel(ctx, resp_channel, f"```{response}```")
+            name = getattr(channel, "name", str(channel.id))  # type: ignore[union-attr]
+            response = f"```{name}: {channel.id}```"  # type: ignore[union-attr]
+            await tbb.send_in_global_channel(ctx, resp_channel, response)
 
     @commands.has_permissions(administrator=True)
     @commands.command(name="lasterror", aliases=["lerror", "_error"])
@@ -267,34 +264,59 @@ class DevCog(commands.Cog):
     @app_commands.command(name="roleids", description="Shows role IDs for one or all roles in the server.")
     @app_commands.guild_only()
     @app_commands.default_permissions(manage_roles=True)
-    @app_commands.describe(role="Role to get the ID for, or omit for all roles.")
-    async def slash_roleids(self, interaction: Interaction, role: Role | None = None):
+    @app_commands.describe(
+        role="Role to get the ID for, or omit for all roles.",
+        output_channel="Channel to send the output to. If omitted, responds here.",
+    )
+    async def slash_roleids(
+        self, interaction: Interaction, role: Role | None = None, output_channel: discord.TextChannel | None = None
+    ):
         """This command gives you role IDs of one or all roles in the server. If a role is provided, shows only that
-        role's ID. If omitted, shows all role IDs."""
+        role's ID. If omitted, shows all role IDs. Optionally send the output to another channel."""
         assert interaction.guild is not None
+        paginator = commands.Paginator()
         if role is None:
-            paginator = commands.Paginator()
             for _role in reversed(interaction.guild.roles):
                 paginator.add_line(f"{_role.name}: {_role.id}")
+        else:
+            paginator.add_line(f"{role.name}: {role.id}")
+        if output_channel:
+            await interaction.response.defer(ephemeral=self.bot.ephemeral)
+            for page in paginator.pages:
+                await output_channel.send(page)
+            await self.bot.send_response(interaction, f"Sent to {output_channel.mention}.")
+        else:
             for page in paginator.pages:
                 await self.bot.send_response(interaction, page)
-        else:
-            await self.bot.send_response(interaction, f"```{role.name}: {role.id}```")
 
     @app_commands.command(name="channelids", description="Shows channel IDs for one or all channels in the server.")
     @app_commands.guild_only()
     @app_commands.default_permissions(manage_guild=True)
-    @app_commands.describe(channel="Channel to get the ID for, or omit for all channels.")
-    async def slash_channelids(self, interaction: Interaction, channel: discord.abc.GuildChannel | None = None):
+    @app_commands.describe(
+        channel="Channel to get the ID for, or omit for all channels.",
+        output_channel="Channel to send the output to. If omitted, responds here.",
+    )
+    async def slash_channelids(
+        self,
+        interaction: Interaction,
+        channel: discord.abc.GuildChannel | None = None,
+        output_channel: discord.TextChannel | None = None,
+    ):
         """This command gives you channel IDs of one or all channels in the server. If a channel is provided, shows
-        only that channel's ID. If omitted, shows all channel IDs."""
+        only that channel's ID. If omitted, shows all channel IDs. Optionally send the output to another channel."""
         assert interaction.guild is not None
+        paginator = commands.Paginator()
         if channel is None:
-            paginator = commands.Paginator()
             for _channel in interaction.guild.channels:
                 paginator.add_line(f"{_channel.name}: {_channel.id}")
-            for page in paginator.pages:
-                await self.bot.send_response(interaction, page)
         else:
             name = getattr(channel, "name", str(channel.id))
-            await self.bot.send_response(interaction, f"```{name}: {channel.id}```")
+            paginator.add_line(f"{name}: {channel.id}")
+        if output_channel:
+            await interaction.response.defer(ephemeral=self.bot.ephemeral)
+            for page in paginator.pages:
+                await output_channel.send(page)
+            await self.bot.send_response(interaction, f"Sent to {output_channel.mention}.")
+        else:
+            for page in paginator.pages:
+                await self.bot.send_response(interaction, page)

--- a/modules/dev.py
+++ b/modules/dev.py
@@ -3,7 +3,6 @@ from copy import copy  # For copying context.
 from io import StringIO  # To return eval output.
 from textwrap import indent  # To format eval output.
 from traceback import format_exc  # To return eval output.
-from typing import Optional  # For type-hinting.
 
 import discord
 from discord import DMChannel, Interaction, Member, Role, app_commands
@@ -16,7 +15,10 @@ async def setup(bot: tbb.TravusBotBase):
     """Setup function ran when module is loaded."""
     cog = DevCog(bot)
     await bot.add_cog(cog)  # Add cog and command help info.
+    # Dev is a shipped TBB module with intentional access to the core command toggle lists.
+    # pylint: disable-next=protected-access
     bot._core_slash_commands.extend([cog.slash_ping, cog.slash_lasterror, cog.slash_roleids, cog.slash_channelids])
+    # pylint: disable-next=protected-access
     bot._core_prefix_commands.extend([cog.ping, cog.lasterror, cog.roleids, cog.channelids])
     bot.add_module(
         "Dev",
@@ -46,7 +48,10 @@ async def setup(bot: tbb.TravusBotBase):
 async def teardown(bot: tbb.TravusBotBase):
     """Teardown function ran when module is unloaded."""
     dev_command_names = ["ping", "lasterror", "roleids", "channelids"]
+    # Dev is a shipped TBB module with intentional access to the core command toggle lists.
+    # pylint: disable-next=protected-access
     bot._core_slash_commands = [com for com in bot._core_slash_commands if com.name not in dev_command_names]
+    # pylint: disable-next=protected-access
     bot._core_prefix_commands = [com for com in bot._core_prefix_commands if com.name not in dev_command_names]
     await bot.remove_cog("DevCog")
     bot.remove_module("Dev")
@@ -137,7 +142,7 @@ class DevCog(commands.Cog):
     @commands.is_owner()
     @commands.guild_only()
     @commands.command(name="sudo", usage="<USER> (CHANNEL) <COMMAND>")
-    async def sudo(self, ctx: commands.Context, user: Member, channel: Optional[tbb.GlobalTextChannel], *, cmd: str):
+    async def sudo(self, ctx: commands.Context, user: Member, channel: tbb.GlobalTextChannel | None, *, cmd: str):
         """This command lets you run commands as another user, optionally in other channels. If the channel argument is
         skipped and the bot fails to parse the argument as a channel it will ignore the channel argument and move on to
         parsing the command instead. In this case the command will be sent from the channel you are currently in."""
@@ -158,7 +163,7 @@ class DevCog(commands.Cog):
     @commands.guild_only()
     @commands.has_permissions(manage_roles=True)
     @commands.command(name="roleids", aliases=["roleid"], usage="<ROLE/all> (OUTPUT CHANNEL/dm)")
-    async def roleids(self, ctx: commands.Context, role: Role | str, resp_channel: Optional[tbb.GlobalTextChannel]):
+    async def roleids(self, ctx: commands.Context, role: Role | str, resp_channel: tbb.GlobalTextChannel | None):
         """This command gives you role IDs of one or all roles in the server depending on if a role or `all` is passed
         along. You can also pass along a channel, in this server or otherwise, in which case the response is sent in
         that channel. Sending `dm` instead of a channel will send you the result in direct messages."""
@@ -182,7 +187,7 @@ class DevCog(commands.Cog):
         self,
         ctx: commands.Context,
         channel: tbb.GlobalChannel | str,
-        resp_channel: Optional[tbb.GlobalTextChannel],
+        resp_channel: tbb.GlobalTextChannel | None,
     ):
         """This command gives you channel IDs of one or all channels in the server depending on if a channel or `all`
         is passed along. You can also pass along a second channel, in this server or otherwise, in which case the
@@ -224,7 +229,7 @@ class DevCog(commands.Cog):
 
     @commands.is_owner()
     @commands.command(name="sync", usage="(guild)")
-    async def sync(self, ctx: commands.Context, scope: Optional[str] = None):
+    async def sync(self, ctx: commands.Context, scope: str | None = None):
         """This command manually syncs the slash command tree with Discord. Use `guild` to sync only to the current
         server. Without arguments it syncs globally. This is a recovery tool for when automatic sync fails."""
         if scope and scope.lower() == "guild":
@@ -263,7 +268,7 @@ class DevCog(commands.Cog):
     @app_commands.guild_only()
     @app_commands.default_permissions(manage_roles=True)
     @app_commands.describe(role="Role to get the ID for, or omit for all roles.")
-    async def slash_roleids(self, interaction: Interaction, role: Optional[Role] = None):
+    async def slash_roleids(self, interaction: Interaction, role: Role | None = None):
         """This command gives you role IDs of one or all roles in the server. If a role is provided, shows only that
         role's ID. If omitted, shows all role IDs."""
         assert interaction.guild is not None
@@ -280,7 +285,7 @@ class DevCog(commands.Cog):
     @app_commands.guild_only()
     @app_commands.default_permissions(manage_guild=True)
     @app_commands.describe(channel="Channel to get the ID for, or omit for all channels.")
-    async def slash_channelids(self, interaction: Interaction, channel: Optional[discord.abc.GuildChannel] = None):
+    async def slash_channelids(self, interaction: Interaction, channel: discord.abc.GuildChannel | None = None):
         """This command gives you channel IDs of one or all channels in the server. If a channel is provided, shows
         only that channel's ID. If omitted, shows all channel IDs."""
         assert interaction.guild is not None

--- a/modules/dev.py
+++ b/modules/dev.py
@@ -5,7 +5,8 @@ from textwrap import indent  # To format eval output.
 from traceback import format_exc  # To return eval output.
 from typing import Optional  # For type-hinting.
 
-from discord import DMChannel, Member, Role  # For type-hinting and exceptions.
+import discord
+from discord import DMChannel, Interaction, Member, Role, app_commands
 from discord.ext import commands  # For implementation of bot commands.
 
 import travus_bot_base as tbb  # TBB functions and classes.
@@ -13,7 +14,10 @@ import travus_bot_base as tbb  # TBB functions and classes.
 
 async def setup(bot: tbb.TravusBotBase):
     """Setup function ran when module is loaded."""
-    await bot.add_cog(DevCog(bot))  # Add cog and command help info.
+    cog = DevCog(bot)
+    await bot.add_cog(cog)  # Add cog and command help info.
+    bot._core_slash_commands.extend([cog.slash_ping, cog.slash_lasterror, cog.slash_roleids, cog.slash_channelids])
+    bot._core_prefix_commands.extend([cog.ping, cog.lasterror, cog.roleids, cog.channelids])
     bot.add_module(
         "Dev",
         "[Travus](https://github.com/Travus):\n\tEval command\n\tRoleID command\n\tChannelID command\n\tLast error "
@@ -29,6 +33,11 @@ async def setup(bot: tbb.TravusBotBase):
     bot.add_command_help(DevCog.roleids, "Dev", {"perms": ["Manage Roles"]}, ["all bot_room", "all dm", "muted"])
     bot.add_command_help(DevCog.lasterror, "Dev", {"perms": ["Administrator"]}, [""])
     bot.add_command_help(DevCog.ping, "Dev", None, [""])
+    bot.add_command_help(DevCog.sync, "Dev", None, ["", "guild"])
+    bot.add_command_help(DevCog.slash_ping, "Dev", None, [""])
+    bot.add_command_help(DevCog.slash_lasterror, "Dev", None, [""])
+    bot.add_command_help(DevCog.slash_roleids, "Dev", None, ["", "@Moderator"])
+    bot.add_command_help(DevCog.slash_channelids, "Dev", None, ["", "#general"])
     bot.add_command_help(
         DevCog.channelids, "Dev", {"perms": ["Manage Channels"]}, ["all bot_room", "all dm", "general"]
     )
@@ -36,7 +45,10 @@ async def setup(bot: tbb.TravusBotBase):
 
 async def teardown(bot: tbb.TravusBotBase):
     """Teardown function ran when module is unloaded."""
-    await bot.remove_cog("DevCog")  # Remove cog and command help info.
+    dev_command_names = ["ping", "lasterror", "roleids", "channelids"]
+    bot._core_slash_commands = [com for com in bot._core_slash_commands if com.name not in dev_command_names]
+    bot._core_prefix_commands = [com for com in bot._core_prefix_commands if com.name not in dev_command_names]
+    await bot.remove_cog("DevCog")
     bot.remove_module("Dev")
     bot.remove_command_help(DevCog)
 
@@ -209,3 +221,75 @@ class DevCog(commands.Cog):
         """This command shows the latency from the bot to Discord's servers. Can be used to check if the bot is
         responsive."""
         await ctx.send(f"Pong! ({round(self.bot.latency * 1000, 2)}ms)")
+
+    @commands.is_owner()
+    @commands.command(name="sync", usage="(guild)")
+    async def sync(self, ctx: commands.Context, scope: Optional[str] = None):
+        """This command manually syncs the slash command tree with Discord. Use `guild` to sync only to the current
+        server. Without arguments it syncs globally. This is a recovery tool for when automatic sync fails."""
+        if scope and scope.lower() == "guild":
+            if ctx.guild is None:
+                await ctx.send("Cannot sync to guild from DMs.")
+                return
+            await ctx.send("Syncing command tree to guild, this may take a moment...")
+            await self.bot.tree.sync(guild=ctx.guild)
+            await ctx.send(f"Command tree synced to guild `{ctx.guild.name}`.")
+        else:
+            await ctx.send("Syncing command tree globally, this may take a moment...")
+            await self.bot.tree.sync()
+            await ctx.send("Command tree synced globally.")
+
+    @app_commands.command(name="ping", description="Shows the bot's latency to Discord.")
+    async def slash_ping(self, interaction: Interaction):
+        """This command shows the latency from the bot to Discord's servers. Can be used to check if the bot is
+        responsive."""
+        await self.bot.send_response(interaction, f"Pong! ({round(self.bot.latency * 1000, 2)}ms)")
+
+    @app_commands.command(name="lasterror", description="Shows the last error the bot encountered.")
+    @app_commands.guild_only()
+    @app_commands.default_permissions(administrator=True)
+    async def slash_lasterror(self, interaction: Interaction):
+        """This command shows the last error the bot has encountered. Errors encountered while loading modules will
+        not be listed by this command. To see the last error encountered while loading modules see the `/module
+        lasterror` command. This command retains this information until another error replaces it, or the bot shuts
+        down."""
+        if self.bot.last_error:
+            error = tbb.clean_no_ctx(self.bot, interaction.guild, self.bot.last_error)
+            await self.bot.send_response(interaction, error)
+        else:
+            await self.bot.send_response(interaction, "There have not been any errors since the last restart.")
+
+    @app_commands.command(name="roleids", description="Shows role IDs for one or all roles in the server.")
+    @app_commands.guild_only()
+    @app_commands.default_permissions(manage_roles=True)
+    @app_commands.describe(role="Role to get the ID for, or omit for all roles.")
+    async def slash_roleids(self, interaction: Interaction, role: Optional[Role] = None):
+        """This command gives you role IDs of one or all roles in the server. If a role is provided, shows only that
+        role's ID. If omitted, shows all role IDs."""
+        assert interaction.guild is not None
+        if role is None:
+            paginator = commands.Paginator()
+            for _role in reversed(interaction.guild.roles):
+                paginator.add_line(f"{_role.name}: {_role.id}")
+            for page in paginator.pages:
+                await self.bot.send_response(interaction, page)
+        else:
+            await self.bot.send_response(interaction, f"```{role.name}: {role.id}```")
+
+    @app_commands.command(name="channelids", description="Shows channel IDs for one or all channels in the server.")
+    @app_commands.guild_only()
+    @app_commands.default_permissions(manage_guild=True)
+    @app_commands.describe(channel="Channel to get the ID for, or omit for all channels.")
+    async def slash_channelids(self, interaction: Interaction, channel: Optional[discord.abc.GuildChannel] = None):
+        """This command gives you channel IDs of one or all channels in the server. If a channel is provided, shows
+        only that channel's ID. If omitted, shows all channel IDs."""
+        assert interaction.guild is not None
+        if channel is None:
+            paginator = commands.Paginator()
+            for _channel in interaction.guild.channels:
+                paginator.add_line(f"{_channel.name}: {_channel.id}")
+            for page in paginator.pages:
+                await self.bot.send_response(interaction, page)
+        else:
+            name = getattr(channel, "name", str(channel.id))
+            await self.bot.send_response(interaction, f"```{name}: {channel.id}```")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,16 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle
-    "F",   # pyflakes
-    "W",   # pycodestyle
-    "B",   # bugbear
-    "I",   # isort
-    "RUF", # ruff
+    "E",    # pycodestyle
+    "F",    # pyflakes
+    "W",    # pycodestyle
+    "B",    # bugbear
+    "I",    # isort
+    "RUF",  # ruff
+    "UP",   # pyupgrade
+    "SIM",  # flake8-simplify
+    "PERF", # perflint
+    "PIE",  # flake8-pie
 ]
 ignore = [
     "RUF001",  # string contains ambiguous unicode character

--- a/travus_bot_base.py
+++ b/travus_bot_base.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 import copy
 import io
 import logging
@@ -207,7 +208,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             self.owner_only, self.guild_only, self.dm_only = False, False, False
 
             if isinstance(command, (app_commands.Command, app_commands.Group)):
-                doc = command.callback.__doc__ if isinstance(command, app_commands.Command) else None
+                doc = command.callback.__doc__ if isinstance(command, app_commands.Command) else command.__doc__
                 self.description = doc.replace("\n", " ") if doc else command.description or "No description found."
                 self.aliases = [command.name]
                 self.guild_only = command.guild_only
@@ -309,17 +310,83 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
                     "usage": "(COMMAND NAME)",
                 }
             )
+            self._is_subcommand_error: bool = False
 
-        async def _send_help_entry(self, com_object):
-            """Help function which sends help entry og single command. Factored out for DRYer code."""
-            if com_object.qualified_name in self.context.bot.help:
-                if com_object.enabled:
-                    embed = self.context.bot.help[com_object.qualified_name].make_help_embed(self.context)
-                    await self.get_destination().send(embed=embed)  # Send command help info.
-                else:
-                    await self.get_destination().send(f"The `{com_object.qualified_name}` command has been disabled.")
+        async def _deliver(self, content: str | None = None, embed: Embed | None = None):
+            """Route output to interaction response or channel depending on invocation method."""
+            if self.context.interaction is not None:
+                await self.context.bot.send_response(self.context.interaction, content or "", embed=embed)
             else:
-                await self.get_destination().send("No help information is registered for this command.")
+                assert self.context.channel is not None
+                if embed is not None:
+                    await self.context.channel.send(content, embed=embed)
+                else:
+                    await self.context.channel.send(content)
+
+        async def _send_help_entry(self, name: str):  # pylint: disable=too-many-return-statements
+            """Look up and send help for a command by name, checking both prefix and slash help dicts."""
+            bot = self.context.bot
+            invoked_via_slash = self.context.interaction is not None
+            core_slash_cmds = bot._core_slash_commands  # pylint: disable=protected-access
+            core_prefix_cmds = bot._core_prefix_commands  # pylint: disable=protected-access
+            core_slash_top_names = {com.name for com in core_slash_cmds}
+
+            if invoked_via_slash:
+                primary, secondary = bot.slash_help, bot.help
+            else:
+                primary, secondary = bot.help, bot.slash_help
+
+            entry = primary.get(name)
+            if entry:
+                if invoked_via_slash:
+                    # Primary is slash_help. Check if core slash cmd is mode-disabled (prefix-only mode).
+                    if name.split(" ")[0] in core_slash_top_names and bot.core_commands_mode == "prefix":
+                        fallback = secondary.get(name)
+                        if fallback:
+                            cmd = bot.get_command(name)
+                            if cmd is not None and cmd.enabled:
+                                await self._deliver(embed=fallback.make_help_embed(self.context))
+                                return
+                        await self._deliver(f"The `{name}` command has been disabled.")
+                        return
+                    await self._deliver(embed=entry.make_help_embed(self.context))
+                    return
+                # Primary is bot.help. Check if prefix command is disabled.
+                cmd = bot.get_command(name)
+                assert cmd is not None
+                # Mode-disabled: command itself or any parent group is a core prefix cmd in slash-only mode.
+                is_mode_disabled = bot.core_commands_mode == "slash" and (
+                    cmd in core_prefix_cmds or any(p in core_prefix_cmds for p in cmd.parents)
+                )
+                if not is_mode_disabled and cmd.enabled:
+                    await self._deliver(embed=entry.make_help_embed(self.context))
+                    return
+                if is_mode_disabled:
+                    fallback = secondary.get(name)
+                    if fallback:
+                        await self._deliver(embed=fallback.make_help_embed(self.context))
+                        return
+                await self._deliver(f"The `{name}` command has been disabled.")
+                return
+
+            # Not in primary — check secondary.
+            fallback = secondary.get(name)
+            if fallback:
+                if invoked_via_slash:
+                    # Secondary is bot.help. Check if prefix command is user-disabled.
+                    cmd = bot.get_command(name)
+                    if cmd and not cmd.enabled and not (cmd in core_prefix_cmds and bot.core_commands_mode == "slash"):
+                        await self._deliver(f"The `{name}` command has been disabled.")
+                        return
+                else:
+                    # Secondary is bot.slash_help. Check if slash command is mode-disabled.
+                    if name.split(" ")[0] in core_slash_top_names and bot.core_commands_mode == "prefix":
+                        await self._deliver(f"No command called `{name}` found.")
+                        return
+                await self._deliver(embed=fallback.make_help_embed(self.context))
+                return
+
+            await self._deliver(f"No command called `{name}` found.")
 
         async def _send_command_list(self, full_mapping: set[Command]):
             """Help function which sends the command list. Factored out for DRYer code."""
@@ -332,7 +399,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             dm_only = {f"`{com.qualified_name}`¹": com for com in non_passing if await can_run(com, new_ctx)}
             filtered_mapping.update(dm_only)
             if not filtered_mapping:
-                await self.get_destination().send("No help information was found.")
+                await self._deliver("No help information was found.")
                 return
             for com_text, com in filtered_mapping.items():
                 if com.qualified_name in self.context.bot.help:
@@ -345,16 +412,22 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             paginator = commands.Paginator(prefix="", suffix="", linesep="")
             paginator.add_line(f"__**Help Info {self.context.message.author.mention}:**__\n\n")
             for category in sorted(categories.keys()):
+                if categories[category] == ["`help`"]:
+                    continue  # Skip categories where `help` is the only visible prefix command.
                 paginator.add_line(f"**{category.title()}**\n")
                 category_commands = [f"{com}, " for com in sorted(categories[category])]
                 category_commands[-1] = f"{category_commands[-1][:-2]}\n\n"  # Replace ', ' with '\n\n' on last command
                 for com in category_commands:
                     paginator.add_line(self.remove_mentions(com))
             end = "1 = In DMs only.\n" if any("¹" in elem for cat in categories.values() for elem in cat) else ""
-            end += f"Use `{self.context.bot.get_bot_prefix()}help <COMMAND>` for more info on individual commands."
+            prefix = "/" if self.context.interaction else self.context.bot.get_bot_prefix()
+            end += f"Use `{prefix}help <COMMAND>` for more info on individual commands."
+            if self.context.bot.core_commands_mode in ("slash", "both"):
+                end += f"\nSlash commands are discoverable via Discord's built-in UI. Use `{prefix}help <COMMAND>` "
+                end += "for details."
             paginator.add_line(end)
             for page in paginator.pages:
-                await self.get_destination().send(page)
+                await self._deliver(page)
 
         async def send_bot_help(self, mapping, /):
             """Function that triggers when help command is used without command."""
@@ -366,9 +439,13 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
 
         async def send_command_help(self, command_object: Command[Any, ..., Any], /):
             """Function that triggers when help command is used with a command."""
-            while command_object.qualified_name not in self.context.bot.help and len(command_object.parents):
+            while (
+                command_object.qualified_name not in self.context.bot.help
+                and command_object.qualified_name not in self.context.bot.slash_help
+                and len(command_object.parents)
+            ):
                 command_object = command_object.parents[0]  # Get parent in case it has help text.
-            await self._send_help_entry(command_object)
+            await self._send_help_entry(command_object.qualified_name)
 
         async def send_cog_help(self, cog: Cog, /):
             """Function that triggers when help command is used with a cog."""
@@ -377,17 +454,34 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
 
         async def send_group_help(self, group: Group[Any, ..., Any], /):
             """Function that triggers when help command is used with a group."""
-            while group.qualified_name not in self.context.bot.help and len(group.parents):
+            while (
+                group.qualified_name not in self.context.bot.help
+                and group.qualified_name not in self.context.bot.slash_help
+                and len(group.parents)
+            ):
                 group = group.parents[0]  # Get parent in case it has help text.
-            await self._send_help_entry(group)
+            await self._send_help_entry(group.qualified_name)
 
         def subcommand_not_found(self, command: Command[Any, ..., Any], string: str, /):
             """Function that returns content of error when subcommand invalid."""
+            self._is_subcommand_error = True
             return f"The `{command.qualified_name}` command has no subcommand called `{string}`."
 
         def command_not_found(self, string: str, /):
             """Function that returns content of error when command not found."""
-            return f"No command called `{string}` found."
+            self._is_subcommand_error = False
+            return string  # Return raw name; send_error_message handles lookup and formatting.
+
+        async def send_error_message(self, error: str | None, /):
+            """Send help error message, checking slash_help before reporting not found."""
+            if error is None:
+                return
+            if error in self.context.bot.help or error in self.context.bot.slash_help:
+                await self._send_help_entry(error)
+            elif not self._is_subcommand_error:
+                await self._deliver(f"No command called `{error}` found.")
+            else:
+                await self._deliver(error)
 
     def __init__(self, database_credentials: DatabaseCredentials, *args, **kwargs):
         """Initialization function loading all necessary information for TravusBotBase class."""
@@ -397,6 +491,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
         self.last_error: str | None = None
         self.extension_ctx: Context | Interaction | None = None
         self.help: dict[str, TravusBotBase._HelpInfo] = {}
+        self.slash_help: dict[str, TravusBotBase._HelpInfo] = {}
         self.modules: dict[str, TravusBotBase._ModuleInfo] = {}
         self.is_connected: int = 0
         self.help_command = self._CustomHelp()
@@ -590,8 +685,10 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
 
     async def _apply_core_commands_mode(self, sync: bool = True):
         """Register/unregister core slash and prefix commands based on core_commands_mode setting."""
-        # Slash commands: add or remove from tree
+        # Slash commands: add or remove from tree (top-level only; subcommands follow their parent group).
         for cmd in self._core_slash_commands:
+            if cmd.parent is not None:
+                continue
             if self.core_commands_mode in ("slash", "both"):
                 if self.tree.get_command(cmd.name) is None:
                     self.tree.add_command(cmd)
@@ -678,27 +775,45 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
     ):
         """Function that is used to add help info to the bot correctly. Used to minimize developmental errors. Command
         should be either a prefix command, prefix command group, app command, or app command group."""
-        self.help[command.qualified_name] = self._HelpInfo(
-            self.get_bot_prefix, command, category, restrictions, examples
-        )
+        info = self._HelpInfo(self.get_bot_prefix, command, category, restrictions, examples)
+        if isinstance(command, (app_commands.Command, app_commands.Group)):
+            self.slash_help[command.qualified_name] = info
+        else:
+            self.help[command.qualified_name] = info
 
-    def remove_command_help(self, command: Command | type[Cog] | str | list[Command | str]):
+    def remove_command_help(
+        self,
+        command: (
+            Command
+            | app_commands.Command
+            | app_commands.Group
+            | type[Cog]
+            | str
+            | list[Command | app_commands.Command | app_commands.Group | str]
+        ),
+    ):
         """Function that is used to remove command help info from the bot correctly. Used to minimize developmental
         errors."""
         if isinstance(command, list):  # Remove all in list, if list is passed.
             for com in command:
-                name = com.qualified_name if isinstance(com, Command) else com
-                if name in self.help:
-                    del self.help[name]
-        elif isinstance(command, Command):  # Remove single if only one is passed.
-            if command.qualified_name in self.help:
-                del self.help[command.qualified_name if isinstance(command, Command) else command]
-        elif issubclass(command.__class__, Cog) and not isinstance(command, str):
-            for com in command(self).walk_commands():
-                if com.qualified_name in self.help:
-                    del self.help[com.qualified_name]
-        elif isinstance(command, str) and command in self.help:
-            del self.help[command]
+                if isinstance(com, (app_commands.Command, app_commands.Group)):
+                    self.slash_help.pop(com.qualified_name, None)
+                else:
+                    name = com.qualified_name if isinstance(com, Command) else com
+                    self.help.pop(name, None)
+        elif isinstance(command, (app_commands.Command, app_commands.Group)):
+            self.slash_help.pop(command.qualified_name, None)
+        elif isinstance(command, Command):
+            self.help.pop(command.qualified_name, None)
+        elif isinstance(command, type) and issubclass(command, Cog):
+            cog_instance = command(self)
+            for com in cog_instance.walk_commands():
+                self.help.pop(com.qualified_name, None)
+            for com in cog_instance.walk_app_commands():
+                self.slash_help.pop(com.qualified_name, None)
+        elif isinstance(command, str):
+            self.help.pop(command, None)
+            self.slash_help.pop(command, None)
 
     async def update_status(
         self,

--- a/travus_bot_base.py
+++ b/travus_bot_base.py
@@ -2,10 +2,10 @@ import copy
 import io
 import logging
 import os
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine, Iterable
 from re import compile as re_cmp  # Regex functions used in clean function for detecting mentions.
 from re import findall
-from typing import Any, Callable, Iterable, Optional, Type, TypeVar
+from typing import Any, TypeVar
 
 import asyncpg
 import discord
@@ -191,8 +191,8 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             get_prefix: Callable,
             command: Command | Group | app_commands.Command | app_commands.Group,
             category: str = "no category",
-            restrictions: Optional[dict[str, list[str] | str]] = None,
-            examples: Optional[list[str]] = None,
+            restrictions: dict[str, list[str] | str] | None = None,
+            examples: list[str] | None = None,
         ):
             """Initialization function loading all necessary information for HelpInfo class."""
             res = restrictions  # Shortening often used variable name.
@@ -201,9 +201,9 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             self.is_slash = isinstance(command, (app_commands.Command, app_commands.Group))
             self.category = category
             self.examples = examples or []
-            self.permissions = res["perms"] if isinstance(res, dict) and "perms" in res.keys() else []
-            self.roles = res["roles"] if isinstance(res, dict) and "roles" in res.keys() else []
-            self.other_restrictions = res["other"] if isinstance(res, dict) and "other" in res.keys() else ""
+            self.permissions = res["perms"] if isinstance(res, dict) and "perms" in res else []
+            self.roles = res["roles"] if isinstance(res, dict) and "roles" in res else []
+            self.other_restrictions = res["other"] if isinstance(res, dict) and "other" in res else ""
             self.owner_only, self.guild_only, self.dm_only = False, False, False
 
             if isinstance(command, (app_commands.Command, app_commands.Group)):
@@ -261,10 +261,10 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             get_prefix: Callable,
             name: str,
             author: str,
-            usage: Optional[Callable[[], str | Embed]] = None,
-            description: Optional[str] = None,
-            extra_credits: Optional[str] = None,
-            image_link: Optional[str | discord.Asset] = None,
+            usage: Callable[[], str | Embed] | None = None,
+            description: str | None = None,
+            extra_credits: str | None = None,
+            image_link: str | discord.Asset | None = None,
         ):
             """Initialization function loading all necessary information for ModuleInfo class."""
             self.get_prefix = get_prefix
@@ -301,7 +301,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
 
         def __init__(self):
             """Initialization function that sets help and usage text for custom help command."""
-            super(TravusBotBase._CustomHelp, self).__init__(
+            super().__init__(
                 command_attrs={
                     "help": """This command shows a list of categorized commands you have access to. If the name of
                     a command is sent along it will show detailed help information for that command, such as what the
@@ -312,7 +312,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
 
         async def _send_help_entry(self, com_object):
             """Help function which sends help entry og single command. Factored out for DRYer code."""
-            if com_object.qualified_name in self.context.bot.help.keys():
+            if com_object.qualified_name in self.context.bot.help:
                 if com_object.enabled:
                     embed = self.context.bot.help[com_object.qualified_name].make_help_embed(self.context)
                     await self.get_destination().send(embed=embed)  # Send command help info.
@@ -335,7 +335,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
                 await self.get_destination().send("No help information was found.")
                 return
             for com_text, com in filtered_mapping.items():
-                if com.qualified_name in self.context.bot.help.keys():
+                if com.qualified_name in self.context.bot.help:
                     command_help = self.context.bot.help[com.qualified_name]  # Get command help info.
                     category = command_help.category.lower() if command_help.category else "no category"
                     if category not in categories:  # Add category if it wasn't encountered before.
@@ -366,7 +366,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
 
         async def send_command_help(self, command_object: Command[Any, ..., Any], /):
             """Function that triggers when help command is used with a command."""
-            while command_object.qualified_name not in self.context.bot.help.keys() and len(command_object.parents):
+            while command_object.qualified_name not in self.context.bot.help and len(command_object.parents):
                 command_object = command_object.parents[0]  # Get parent in case it has help text.
             await self._send_help_entry(command_object)
 
@@ -377,7 +377,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
 
         async def send_group_help(self, group: Group[Any, ..., Any], /):
             """Function that triggers when help command is used with a group."""
-            while group.qualified_name not in self.context.bot.help.keys() and len(group.parents):
+            while group.qualified_name not in self.context.bot.help and len(group.parents):
                 group = group.parents[0]  # Get parent in case it has help text.
             await self._send_help_entry(group)
 
@@ -393,16 +393,16 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
         """Initialization function loading all necessary information for TravusBotBase class."""
         super().__init__(*args, **kwargs)
         self.log: logging.Logger = BOT_LOG
-        self.last_module_error: Optional[str] = None
-        self.last_error: Optional[str] = None
-        self.extension_ctx: Optional[Context] = None
+        self.last_module_error: str | None = None
+        self.last_error: str | None = None
+        self.extension_ctx: Context | None = None
         self.help: dict[str, TravusBotBase._HelpInfo] = {}
         self.modules: dict[str, TravusBotBase._ModuleInfo] = {}
         self.is_connected: int = 0
         self.help_command = self._CustomHelp()
         self.config: dict[str, str] = {}
         self._db_creds = database_credentials
-        self.prefix: Optional[str] = None
+        self.prefix: str | None = None
         self.delete_messages: int = 1
         self.ephemeral: bool = True
         self.core_commands_mode: str = "slash"
@@ -411,7 +411,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
         self.send_long_text: Callable[[Context, str], Coroutine[Any, Any, None]] = send_long_text
 
     async def get_context(
-        self, origin: Message | Interaction, /, *, cls: Optional[Type[_ContextT]] = None
+        self, origin: Message | Interaction, /, *, cls: type[_ContextT] | None = None
     ) -> TBBContext | _ContextT:
         """Create TBBContexts with correct bot typing."""
         return await super().get_context(origin, cls=cls or TBBContext)
@@ -502,14 +502,15 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
                 self.modules = old_modules
                 if propagate:
                     raise
-                if isinstance(e.original, DependencyError):
-                    if all(load_module(default_list, dependency) for dependency in e.original.missing_dependencies):
-                        try:
-                            default_list.append(module)
-                            if load_module(default_list, module, True):
-                                return True
-                        except Exception as ee:
-                            e = ee
+                if isinstance(e.original, DependencyError) and all(
+                    load_module(default_list, dependency) for dependency in e.original.missing_dependencies
+                ):
+                    try:
+                        default_list.append(module)
+                        if load_module(default_list, module, True):
+                            return True
+                    except Exception as ee:
+                        e = ee
                 self.log.error(f"Default module '{module}' encountered and error.\n\n{e!s}")
                 self.last_module_error = f"The `{module}` module failed while loading. The error was:\n\n{e!s}"
                 return False
@@ -620,10 +621,10 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
         self,
         name: str,
         author: str,
-        usage: Optional[Callable[[], str | Embed]] = None,
-        description: Optional[str] = None,
-        additional_credits: Optional[str] = None,
-        image_link: Optional[str | discord.Asset] = None,
+        usage: Callable[[], str | Embed] | None = None,
+        description: str | None = None,
+        additional_credits: str | None = None,
+        image_link: str | discord.Asset | None = None,
     ):
         """Function that is used to add module info to the bot correctly. Used to minimize developmental errors."""
         info = self._ModuleInfo(self.get_bot_prefix, name, author, usage, description, additional_credits, image_link)
@@ -649,25 +650,24 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
 
     async def update_command_states(self):
         """Function that get command state (hidden, disabled) for every command currently loaded."""
-        async with self.db.acquire() as conn:
-            async with conn.transaction():
-                for command in self.commands:
-                    cog_com_name = f"{f'{command.cog_name}.' if command.cog_name else ''}{command.name}"
-                    command_state = await conn.fetchval(
-                        "SELECT state FROM command_states WHERE command = $1;", cog_com_name
-                    )
-                    if command_state is None:  # If a command has no state registered, set it to visible and enables.
-                        command_state = (0,)
-                        await conn.execute("INSERT INTO command_states VALUES ($1, $2)", cog_com_name, 0)
-                    if command_state == 1:  # Set command to be hidden.
-                        command.enabled = True
-                        command.hidden = True
-                    elif command_state == 2:  # Set command to be disabled.
-                        command.enabled = False
-                        command.hidden = False
-                    elif command_state == 3:  # Set command to be hidden and disabled.
-                        command.enabled = False
-                        command.hidden = True
+        async with self.db.acquire() as conn, conn.transaction():
+            for command in self.commands:
+                cog_com_name = f"{f'{command.cog_name}.' if command.cog_name else ''}{command.name}"
+                command_state = await conn.fetchval(
+                    "SELECT state FROM command_states WHERE command = $1;", cog_com_name
+                )
+                if command_state is None:  # If a command has no state registered, set it to visible and enables.
+                    command_state = (0,)
+                    await conn.execute("INSERT INTO command_states VALUES ($1, $2)", cog_com_name, 0)
+                if command_state == 1:  # Set command to be hidden.
+                    command.enabled = True
+                    command.hidden = True
+                elif command_state == 2:  # Set command to be disabled.
+                    command.enabled = False
+                    command.hidden = False
+                elif command_state == 3:  # Set command to be hidden and disabled.
+                    command.enabled = False
+                    command.hidden = True
 
     def add_command_help(
         self,
@@ -682,7 +682,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             self.get_bot_prefix, command, category, restrictions, examples
         )
 
-    def remove_command_help(self, command: Command | Type[Cog] | str | list[Command | str]):
+    def remove_command_help(self, command: Command | type[Cog] | str | list[Command | str]):
         """Function that is used to remove command help info from the bot correctly. Used to minimize developmental
         errors."""
         if isinstance(command, list):  # Remove all in list, if list is passed.
@@ -697,13 +697,12 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             for com in command(self).walk_commands():
                 if com.qualified_name in self.help:
                     del self.help[com.qualified_name]
-        elif isinstance(command, str):
-            if command in self.help:
-                del self.help[command]
+        elif isinstance(command, str) and command in self.help:
+            del self.help[command]
 
     async def update_status(
         self,
-        text: Optional[str] = None,
+        text: str | None = None,
         activity_type: discord.ActivityType = discord.ActivityType.listening,
     ):
         """Update bot presence/status. If no text is given, defaults to showing the current prefix/help info
@@ -735,7 +734,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             )
             bot_desc = bot_desc or "No description for the bot found. Set description with `botconfig` command."
             self.add_module(self.user.name, bot_author, None, bot_desc, bot_credits, self.user.display_avatar)
-        await self._update_status()
+        await self.update_status()
         self.is_connected = 1  # Flag that the bot is currently connected to Discord.
         self.log.info(f"{self.user.name} is ready!\n------------------------------")
 
@@ -802,9 +801,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
     async def _on_app_command_error(self, interaction: Interaction, error: app_commands.AppCommandError):
         """Global error handler for app command errors. Assigned to tree.on_error in setup_hook."""
         command_name = interaction.command.qualified_name if interaction.command else "unknown"
-        if isinstance(error, app_commands.CommandOnCooldown):
-            pass
-        elif isinstance(error, app_commands.NoPrivateMessage):
+        if isinstance(error, (app_commands.CommandOnCooldown, app_commands.NoPrivateMessage)):
             pass
         elif isinstance(error, app_commands.MissingPermissions):
             self.log.warning(
@@ -846,7 +843,7 @@ def parse_time(
     return t_total
 
 
-async def send_in_global_channel(ctx: Context, channel: Optional[GlobalTextChannel], msg: str, other_dms: bool = False):
+async def send_in_global_channel(ctx: Context, channel: GlobalTextChannel | None, msg: str, other_dms: bool = False):
     """Sends a message in any text channel across servers and DMs. Has flag to allow sending to foreign DMs."""
     user = ctx.author
     try:
@@ -910,7 +907,7 @@ async def del_message(msg: Message):
 
 def _clean(
     bot: TravusBotBase,
-    guild: Optional[discord.Guild],
+    guild: discord.Guild | None,
     text: str,
     escape_markdown: bool = True,
     replace_backticks: bool = False,
@@ -967,7 +964,7 @@ def clean(ctx: Context, text: str, escape_markdown: bool = True, replace_backtic
 
 def clean_no_ctx(
     bot: TravusBotBase,
-    guild: Optional[discord.Guild],
+    guild: discord.Guild | None,
     text: str,
     escape_markdown: bool = True,
     replace_backticks: bool = False,

--- a/travus_bot_base.py
+++ b/travus_bot_base.py
@@ -276,13 +276,13 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
             self.image = image_link
             self.usage = usage
 
-        def make_about_embed(self, ctx: Context) -> Embed:
+        def make_about_embed(self, user: User | Member) -> Embed:
             """Creates embeds for module based on info stored in class."""
             embed = Embed(colour=discord.Color(0x4A4A4A), timestamp=discord.utils.utcnow())
             description = self.description.replace("_prefix_", self.get_prefix())
             embed.description = description if len(description) < 4097 else f"{description[:4092]}..."
             embed.set_author(name=self.name)
-            embed.set_footer(text=ctx.author.display_name, icon_url=ctx.author.display_avatar)
+            embed.set_footer(text=user.display_name, icon_url=user.display_avatar)
             if self.image:
                 embed.set_thumbnail(url=self.image)
             author = self.author if len(self.author) < 1024 else f"{self.author[:1020]}..."
@@ -292,7 +292,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
                 extra_credits = self.credits if len(self.credits) < 1024 else f"{self.credits[:1020]}..."
                 embed.add_field(name="Authored By", value=author, inline=True)
                 embed.add_field(name="Additional Credits", value=extra_credits, inline=True)
-            return check_embed_length(ctx.author, embed)
+            return check_embed_length(user, embed)
 
     class _CustomHelp(commands.HelpCommand):
         """Class for custom help command."""
@@ -395,7 +395,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
         self.log: logging.Logger = BOT_LOG
         self.last_module_error: str | None = None
         self.last_error: str | None = None
-        self.extension_ctx: Context | None = None
+        self.extension_ctx: Context | Interaction | None = None
         self.help: dict[str, TravusBotBase._HelpInfo] = {}
         self.modules: dict[str, TravusBotBase._ModuleInfo] = {}
         self.is_connected: int = 0

--- a/travus_bot_base.py
+++ b/travus_bot_base.py
@@ -26,6 +26,7 @@ from discord import (
     Thread,
     User,
     VoiceChannel,
+    app_commands,
     utils,
 )
 from discord.ext import commands
@@ -177,7 +178,7 @@ class TBBContext(commands.Context):
     bot: "TravusBotBase"
 
 
-class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
+class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instance-attributes
     """Custom bot class with database connection."""
 
     db: asyncpg.Pool
@@ -188,7 +189,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
         def __init__(
             self,
             get_prefix: Callable,
-            command: Command,
+            command: Command | Group | app_commands.Command | app_commands.Group,
             category: str = "no category",
             restrictions: Optional[dict[str, list[str] | str]] = None,
             examples: Optional[list[str]] = None,
@@ -197,22 +198,30 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
             res = restrictions  # Shortening often used variable name.
             self.get_prefix = get_prefix
             self.name = command.qualified_name
-            self.description = command.help.replace("\n", " ") if command.help else "No description found."
-            self.aliases = list(command.aliases) or []
-            self.aliases.append(command.name)
+            self.is_slash = isinstance(command, (app_commands.Command, app_commands.Group))
             self.category = category
             self.examples = examples or []
             self.permissions = res["perms"] if isinstance(res, dict) and "perms" in res.keys() else []
             self.roles = res["roles"] if isinstance(res, dict) and "roles" in res.keys() else []
             self.other_restrictions = res["other"] if isinstance(res, dict) and "other" in res.keys() else ""
             self.owner_only, self.guild_only, self.dm_only = False, False, False
-            for check in command.checks:
-                if "is_owner" in str(check):
-                    self.owner_only = True
-                if "guild_only" in str(check):
-                    self.guild_only = True
-                if "dm_only" in str(check):
-                    self.dm_only = True
+
+            if isinstance(command, (app_commands.Command, app_commands.Group)):
+                doc = command.callback.__doc__ if isinstance(command, app_commands.Command) else None
+                self.description = doc.replace("\n", " ") if doc else command.description or "No description found."
+                self.aliases = [command.name]
+                self.guild_only = command.guild_only
+            else:
+                self.description = command.help.replace("\n", " ") if command.help else "No description found."
+                self.aliases = list(command.aliases) or []
+                self.aliases.append(command.name)
+                for check in command.checks:
+                    if "is_owner" in str(check):
+                        self.owner_only = True
+                    if "guild_only" in str(check):
+                        self.guild_only = True
+                    if "dm_only" in str(check):
+                        self.dm_only = True
 
         def make_help_embed(self, ctx: Context) -> Embed:
             """Creates embeds for command based on info stored in class."""
@@ -233,9 +242,10 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
             )
             restrictions += f"\n{self.other_restrictions}" if self.other_restrictions else ""
             embed.add_field(name="Restrictions", value=f"```{restrictions[:1017]}```", inline=True)
+            prefix = "/" if self.is_slash else self.get_prefix()
             examples = "\n".join(
                 [
-                    f"`{self.get_prefix()}{self.name} {example}`" if example else f"`{self.get_prefix()}{self.name}`"
+                    f"`{prefix}{self.name} {example}`" if example else f"`{prefix}{self.name}`"
                     for example in self.examples
                 ]
             )
@@ -394,6 +404,10 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
         self._db_creds = database_credentials
         self.prefix: Optional[str] = None
         self.delete_messages: int = 1
+        self.ephemeral: bool = True
+        self.core_commands_mode: str = "slash"
+        self._core_slash_commands: list[app_commands.Command | app_commands.Group] = []
+        self._core_prefix_commands: list[Command | commands.Group] = []
         self.send_long_text: Callable[[Context, str], Coroutine[Any, Any, None]] = send_long_text
 
     async def get_context(
@@ -421,12 +435,20 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
                 await conn.execute("INSERT INTO settings VALUES ('bot_description', '') ON CONFLICT (key) DO NOTHING")
                 await conn.execute("INSERT INTO settings VALUES ('delete_messages', '0') ON CONFLICT (key) DO NOTHING")
                 await conn.execute("INSERT INTO settings VALUES ('prefix', '!') ON CONFLICT (key) DO NOTHING")
+                await conn.execute("INSERT INTO settings VALUES ('ephemeral', '1') ON CONFLICT (key) DO NOTHING")
+                await conn.execute(
+                    "INSERT INTO settings VALUES ('core_commands_mode', 'slash') ON CONFLICT (key) DO NOTHING"
+                )
             loaded_prefix = await self.db.fetchval("SELECT value FROM settings WHERE key = 'prefix'")
             delete_msgs = await conn.fetchval("SELECT value FROM settings WHERE key = 'delete_messages'")
+            ephemeral = await conn.fetchval("SELECT value FROM settings WHERE key = 'ephemeral'")
+            core_mode = await conn.fetchval("SELECT value FROM settings WHERE key = 'core_commands_mode'")
             config = await conn.fetch("SELECT key, value FROM config")
 
         self.prefix = loaded_prefix or None
         self.delete_messages = int(delete_msgs) if delete_msgs is not None else 1
+        self.ephemeral = bool(int(ephemeral)) if ephemeral is not None else True
+        self.core_commands_mode = core_mode if core_mode in ("slash", "prefix", "both") else "slash"
         self.add_command_help(
             next(com for com in self.commands if com.name == "help"), "Core", None, ["", "about", "help"]
         )  # Add help info for help command.
@@ -512,9 +534,12 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
         for mod in list(default_modules):
             await load_module(default_modules, mod)
         await self.update_command_states()  # Make sure commands are in the right state. (hidden, disabled)
+        await self.apply_core_commands_mode(sync=False)  # Enforce mode before syncing.
+        await self.tree.sync()  # Sync tree after loading default modules (picks up module slash commands).
 
     async def setup_hook(self):
         """Called after the bot is logged in but before connecting to the gateway. Loads DB options and commands."""
+        self.tree.on_error = self._on_app_command_error
         await self._load_db_options()
         await self._load_default_commands()
         self.loop.create_task(self._load_default_modules())  # Runs after bot is ready (waits internally).
@@ -552,6 +577,33 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
             return self.prefix
         assert self.user is not None
         return f"{self.user.mention} "
+
+    async def send_response(self, interaction: Interaction, content: str = "", **kwargs) -> None:
+        """Send a response to an interaction, respecting the ephemeral setting. Uses followup if already responded."""
+        if "ephemeral" not in kwargs:
+            kwargs["ephemeral"] = self.ephemeral
+        if interaction.response.is_done():
+            await interaction.followup.send(content, **kwargs)
+        else:
+            await interaction.response.send_message(content, **kwargs)
+
+    async def apply_core_commands_mode(self, sync: bool = True):
+        """Register/unregister core slash and prefix commands based on core_commands_mode setting."""
+        # Slash commands: add or remove from tree
+        for cmd in self._core_slash_commands:
+            if self.core_commands_mode in ("slash", "both"):
+                if self.tree.get_command(cmd.name) is None:
+                    self.tree.add_command(cmd)
+            else:
+                if self.tree.get_command(cmd.name) is not None:
+                    self.tree.remove_command(cmd.name)
+        # Prefix commands: enable or disable (help is excluded — always both)
+        for cmd in self._core_prefix_commands:
+            if cmd.name == "help":
+                continue
+            cmd.enabled = self.core_commands_mode in ("prefix", "both")
+        if sync:
+            await self.tree.sync()
 
     def check_dependencies(self, dependencies: list[str]):
         """Checks if all dependencies are met. Raises DependencyError with the missing dependencies if not."""
@@ -619,14 +671,13 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
 
     def add_command_help(
         self,
-        command,
+        command: Command | Group | app_commands.Command | app_commands.Group,
         category: str = "no category",
         restrictions: dict[str, list[str] | str] | None = None,
         examples: list[str] | None = None,
     ):
         """Function that is used to add help info to the bot correctly. Used to minimize developmental errors. Command
-        should be either a command or a command group."""
-        # The Command argument is currently not typed due to type checking issues in PyCharm, should be type 'Command'.
+        should be either a prefix command, prefix command group, app command, or app command group."""
         self.help[command.qualified_name] = self._HelpInfo(
             self.get_bot_prefix, command, category, restrictions, examples
         )
@@ -650,6 +701,23 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
             if command in self.help:
                 del self.help[command]
 
+    async def update_status(
+        self,
+        text: Optional[str] = None,
+        activity_type: discord.ActivityType = discord.ActivityType.listening,
+    ):
+        """Update bot presence/status. If no text is given, defaults to showing the current prefix/help info
+        based on core commands mode. If text is given, it is used as-is with the given activity type."""
+        if text is None:
+            if self.core_commands_mode == "slash":
+                text = "/help"
+            elif self.core_commands_mode == "both":
+                text = f"prefix: {self.prefix} | /help" if self.prefix else "/help"
+            else:
+                text = f"prefix: {self.prefix}" if self.prefix else "pings only"
+        activity = discord.Activity(type=activity_type, name=text)
+        await self.change_presence(activity=activity)
+
     async def on_ready(self):
         """This function runs every time the bot connects to Discord. This happens multiple times.
         Sets about command and bot status. These require the bot to be online and hence are in here."""
@@ -667,10 +735,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
             )
             bot_desc = bot_desc or "No description for the bot found. Set description with `botconfig` command."
             self.add_module(self.user.name, bot_author, None, bot_desc, bot_credits, self.user.display_avatar)
-        activity = discord.Activity(
-            type=discord.ActivityType.listening, name=f"prefix: {self.prefix}" if self.prefix else "pings only"
-        )
-        await self.change_presence(activity=activity)  # Display status message.
+        await self._update_status()
         self.is_connected = 1  # Flag that the bot is currently connected to Discord.
         self.log.info(f"{self.user.name} is ready!\n------------------------------")
 
@@ -688,6 +753,8 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
 
     async def on_command(self, ctx: Context):
         """Deletes command if command deletion is set."""
+        if ctx.interaction is not None:  # Don't delete interaction-triggered messages.
+            return
         if self.delete_messages and ctx.guild:  # If the message is in a server and the delete messages flag is true.
             try:  # Try to delete message.
                 await ctx.message.delete()
@@ -731,6 +798,26 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors
         elif error is not None:  # Log error to console.
             self.log.warning(f"{ctx.author.id}: {error}")
         self.last_error = f"[{cur_time()}] {ctx.author.id}: {error}"
+
+    async def _on_app_command_error(self, interaction: Interaction, error: app_commands.AppCommandError):
+        """Global error handler for app command errors. Assigned to tree.on_error in setup_hook."""
+        command_name = interaction.command.qualified_name if interaction.command else "unknown"
+        if isinstance(error, app_commands.CommandOnCooldown):
+            pass
+        elif isinstance(error, app_commands.NoPrivateMessage):
+            pass
+        elif isinstance(error, app_commands.MissingPermissions):
+            self.log.warning(
+                f"{interaction.user.id}: Command '/{command_name}' requires additional permissions: "
+                f"{', '.join(error.missing_permissions)}"
+            )
+        elif isinstance(error, app_commands.CheckFailure):
+            pass
+        elif isinstance(error.__cause__, Forbidden):
+            self.log.warning(f"{interaction.user.id}: Missing permissions.")
+        elif error is not None:
+            self.log.warning(f"{interaction.user.id}: /{command_name}: {error}")
+        self.last_error = f"[{cur_time()}] {interaction.user.id}: /{command_name}: {error}"
 
 
 def parse_time(

--- a/travus_bot_base.py
+++ b/travus_bot_base.py
@@ -125,7 +125,7 @@ class GlobalChannel(commands.Converter):
         except commands.ThreadNotFound:
             pass
         try:
-            converted = ctx.bot.get_channel(int(argument))
+            converted = await ctx.bot.fetch_channel(int(argument))
             if converted is None:
                 raise commands.UserInputError("Could not identify channel.")
             return converted
@@ -535,7 +535,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
         for mod in list(default_modules):
             await load_module(default_modules, mod)
         await self.update_command_states()  # Make sure commands are in the right state. (hidden, disabled)
-        await self.apply_core_commands_mode(sync=False)  # Enforce mode before syncing.
+        await self._apply_core_commands_mode(sync=False)  # Enforce mode before syncing.
         await self.tree.sync()  # Sync tree after loading default modules (picks up module slash commands).
 
     async def setup_hook(self):
@@ -588,7 +588,7 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
         else:
             await interaction.response.send_message(content, **kwargs)
 
-    async def apply_core_commands_mode(self, sync: bool = True):
+    async def _apply_core_commands_mode(self, sync: bool = True):
         """Register/unregister core slash and prefix commands based on core_commands_mode setting."""
         # Slash commands: add or remove from tree
         for cmd in self._core_slash_commands:


### PR DESCRIPTION
Closes #8.

Implements full slash command support as designed in the issue, with configurable mode control over which command types are active.

**Changes:**
- Added slash versions of all core commands (`/module`, `/default`, `/config`, `/command`, `/about`, `/usage`, `/help`) and dev module commands (`/ping`, `/lasterror`, `/roleids`, `/channelids`)
- `botconfig corecommands <slash/prefix/both>` controls whether core commands are registered as slash, prefix, or both (default: `slash`); persisted across restarts
- `botconfig ephemeral` toggle for ephemeral slash responses (default: on)
- `/help` bridges into `_CustomHelp` via context; help system updated to support slash invocation, mode-aware output, and correct mode-disabled resolution for both top-level commands and subcommands
- `add_command_help` and `remove_command_help` now handle slash commands alongside prefix commands
- Bot status reflects the active core commands mode
- Updated wiki (Module-Creation, Documentation) to cover slash command registration