### PR TITLE
v2.0.1: required_config on slash commands and dependency loading fixes

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2022 Travus
+Copyright (c) 2019-2026 Travus
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "travus-bot-base"
-version = "2.0.0"
+version = "2.0.1"
 requires-python = ">=3.12"
 dependencies = [
-    "discord.py>=2.7,<3",
-    "pyyaml>=6,<7",
-    "requests>=2.28,<3",
-    "asyncpg>=0.27,<1",
-    "aiohttp>=3.9,<4",
+    "discord.py>=2.7.1,<3",
+    "pyyaml>=6.0.3,<7",
+    "requests>=2.34.2,<3",
+    "asyncpg>=0.31.0,<1",
+    "aiohttp>=3.13.5,<4",
 ]
 
 [build-system]
@@ -16,10 +16,10 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 dev = [
-    "black==26.3.1",
-    "ruff==0.15.6",
+    "black==26.5.1",
+    "ruff==0.15.13",
     "pylint==4.0.5",
-    "pyright==1.1.408",
+    "pyright==1.1.409",
 ]
 
 [tool.black]

--- a/setup_requirements.txt
+++ b/setup_requirements.txt
@@ -1,2 +1,2 @@
-pyyaml
-requests
+pyyaml>=6.0.3,<7
+requests>=2.34.2,<3

--- a/travus_bot_base.py
+++ b/travus_bot_base.py
@@ -590,8 +590,11 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
     async def _load_default_modules(self):
         """Load default modules once bot has cached."""
 
+        # pylint: disable-next=too-many-return-statements
         async def load_module(default_list: list[str], module: str, propagate=False) -> bool:
             """Attempt to load a module, and recursively attempts to load dependencies."""
+            if f"modules.{module}" in self.extensions:
+                return True
             if module not in default_list:
                 return False
             default_list.remove(module)

--- a/travus_bot_base.py
+++ b/travus_bot_base.py
@@ -56,7 +56,7 @@ class DependencyError(commands.CommandError):
         super().__init__(self.message)
 
 
-class ConfigError(commands.CommandError):
+class ConfigError(commands.CommandError, app_commands.CheckFailure):  # pylint: disable=too-many-ancestors
     """Custom exception raised when missing config options."""
 
     def __init__(self, message: str = ""):
@@ -66,23 +66,41 @@ class ConfigError(commands.CommandError):
 
 
 def required_config(requirements: Iterable[str]):
-    """Function that makes sure config options are set."""
+    """Decorator that makes sure config options are set. Works on prefix, slash, and hybrid commands."""
+    requirements = list(requirements)
+    user_message = (
+        "This command requires the following missing configuration options to be set: {missing}.\n"
+        "Please contact an administrator for assistance."
+    )
 
-    async def predicate(predicate_ctx: Context) -> bool:
-        if predicate_ctx.command is None:
+    def _missing(config: Iterable[str]) -> str:
+        return ", ".join(f"`{requirement}`" for requirement in requirements if requirement not in config)[:1850]
+
+    async def prefix_predicate(ctx: Context) -> bool:
+        if ctx.command is None:
             BOT_LOG.error("Required config was used on non-command, this is not supported")
             return True
-        missing = [f"`{requirement}`" for requirement in requirements if requirement not in predicate_ctx.bot.config]
-        missing_str = ", ".join(missing)[:1850]
+        missing_str = _missing(ctx.bot.config)
         if missing_str:
-            await predicate_ctx.send(
-                f"This command requires the following missing configuration options to be set: {missing_str}.\nPlease "
-                "contact an administrator for assistance."
-            )
-            raise ConfigError(f"Command {predicate_ctx.command.qualified_name} missing config options: {missing_str}")
-        return not missing_str
+            await ctx.send(user_message.format(missing=missing_str))
+            raise ConfigError(f"Command {ctx.command.qualified_name} missing config options: {missing_str}")
+        return True
 
-    return commands.check(predicate)
+    async def slash_predicate(interaction: Interaction) -> bool:
+        bot: TravusBotBase = interaction.client  # type: ignore[assignment]
+        command_name = interaction.command.qualified_name if interaction.command else "unknown"
+        missing_str = _missing(getattr(bot, "config", {}))
+        if missing_str:
+            await bot.send_response(interaction, user_message.format(missing=missing_str), ephemeral=True)
+            raise ConfigError(f"Command /{command_name} missing config options: {missing_str}")
+        return True
+
+    def decorator(func):
+        func = commands.check(prefix_predicate)(func)
+        func = app_commands.check(slash_predicate)(func)
+        return func
+
+    return decorator
 
 
 class DatabaseCredentials:

--- a/travus_bot_base.py
+++ b/travus_bot_base.py
@@ -615,12 +615,17 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
                 self.modules = old_modules
                 if propagate:
                     raise
-                if isinstance(e.original, DependencyError) and all(
-                    load_module(default_list, dependency) for dependency in e.original.missing_dependencies
-                ):
+                deps_loaded = False
+                if isinstance(e.original, DependencyError):
+                    deps_loaded = True
+                    for dependency in e.original.missing_dependencies:
+                        if not await load_module(default_list, dependency):
+                            deps_loaded = False
+                            break
+                if deps_loaded:
                     try:
                         default_list.append(module)
-                        if load_module(default_list, module, True):
+                        if await load_module(default_list, module, True):
                             return True
                     except Exception as ee:
                         e = ee

--- a/travus_bot_base.py
+++ b/travus_bot_base.py
@@ -615,14 +615,9 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
                 self.modules = old_modules
                 if propagate:
                     raise
-                deps_loaded = False
-                if isinstance(e.original, DependencyError):
-                    deps_loaded = True
-                    for dependency in e.original.missing_dependencies:
-                        if not await load_module(default_list, dependency):
-                            deps_loaded = False
-                            break
-                if deps_loaded:
+                if isinstance(e.original, DependencyError) and await all_deps_loaded(
+                    default_list, e.original.missing_dependencies
+                ):
                     try:
                         default_list.append(module)
                         if await load_module(default_list, module, True):
@@ -643,6 +638,13 @@ class TravusBotBase(Bot):  # pylint: disable=too-many-ancestors, too-many-instan
                 self.last_module_error = f"The `{module}` module failed while loading. The error was:\n\n{e!s}"
                 return False
             self.log.info(f"Default module '{module}' loaded.")
+            return True
+
+        async def all_deps_loaded(default_list: list[str], deps: Iterable[str]) -> bool:
+            """Recursively load each dep; return True iff every load succeeded (short-circuits)."""
+            for dep in deps:
+                if not await load_module(default_list, dep):
+                    return False
             return True
 
         async with self.db.acquire() as conn:


### PR DESCRIPTION
## Summary

- `required_config` decorator now works on slash and hybrid commands, not just prefix. `ConfigError` inherits from both `commands.CommandError` and `app_commands.CheckFailure`; the decorator stacks `commands.check` and `app_commands.check`. The slash predicate uses `bot.send_response`.
- Fixed default-module dependency loading: a relic of the partial 2.0 migration left `load_module` calls un-awaited inside `all()` and `if`, so coroutine objects were silently truthy. The recovery path now correctly awaits, short-circuits, and (via a new early-return) treats already-loaded modules as success so transitive sibling resolution doesn't double-trip.
- Version bump to 2.0.1; refreshed production lower-bound pins and dev tool versions to current latest on PyPI; LICENSE year updated to 2026.