### PR TITLE
Exclude already-default modules from `/default add` autocomplete

### DIFF
--- a/core_commands.py
+++ b/core_commands.py
@@ -1070,8 +1070,15 @@ class CoreFunctionalityCog(commands.Cog):
     async def slash_default_add_autocomplete(
         self, _interaction: Interaction, current: str
     ) -> list[app_commands.Choice[str]]:
-        """Autocomplete for /default add — shows available modules on disk."""
-        available = [mod.replace(".py", "") for mod in listdir("modules") if mod.endswith(".py")]
+        """Autocomplete for /default add — shows modules on disk that aren't already defaults."""
+        async with self.bot.db.acquire() as conn:
+            result = await conn.fetch("SELECT module FROM default_modules")
+        defaults = {val["module"] for val in result}
+        available = [
+            mod.replace(".py", "")
+            for mod in listdir("modules")
+            if mod.endswith(".py") and mod.replace(".py", "") not in defaults
+        ]
         return [app_commands.Choice(name=name, value=name) for name in available if current.lower() in name.lower()][
             :25
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "travus-bot-base"
-version = "2.0.1"
+version = "2.0.2"
 requires-python = ">=3.12"
 dependencies = [
     "discord.py>=2.7.1,<3",


### PR DESCRIPTION
# Exclude already-default modules from `/default add` autocomplete

Closes #12.

## Problem

`/default add` autocomplete listed every `.py` file in `modules/`, including modules already registered in the `default_modules` table. Suggesting modules that are already defaults is noise, the same way `/module load` only offers modules that aren't already loaded, `/default add` should only offer modules that aren't defaults yet.

## Fix

`slash_default_add_autocomplete` now reads the current `default_modules` table (the same query the remove-side autocomplete uses) and subtracts those names from the on-disk module list before building choices:

```python
async with self.bot.db.acquire() as conn:
    result = await conn.fetch("SELECT module FROM default_modules")
defaults = {val["module"] for val in result}
available = [
    mod.replace(".py", "")
    for mod in listdir("modules")
    if mod.endswith(".py") and mod.replace(".py", "") not in defaults
]
```

The case-insensitive substring match on `current` and the 25-choice cap are unchanged. No other autocomplete is affected.

## Behavior

- Modules already in `default_modules` no longer appear in `/default add` suggestions.
- Modules on disk that aren't defaults still appear.
- A module reappears in suggestions once `/default remove` drops it (the table is re-read each call).

Also bumps the version to `2.0.2`.
