### PR TITLE
Make baked-in config.yml optional in the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM python:3.14-slim
 WORKDIR /usr/src/app
 
 COPY pyproject.toml .
-COPY *.py .
-COPY config.yml .
+# config.yml is optional: bake it in by placing it in the build context, or leave it out and
+# mount one at runtime. The bracket glob skips it silently when absent instead of failing the
+# build, and *.py guarantees the COPY always has at least one matching source.
+COPY *.py config.ym[l] ./
 COPY modules/ modules/
 
 RUN pip install --no-cache-dir .
+RUN test -f config.yml || echo "WARNING: no config.yml baked into image; mount one to /usr/src/app/config.yml at runtime or the bot will exit on startup."
 CMD ["python", "/usr/src/app/main.py"]


### PR DESCRIPTION
## Problem

The Dockerfile's `COPY config.yml .` is an explicit copy, so the build hard-fails with a "not found" error whenever no config has been generated in the current directory locally. There is no way to build an image meant to receive its config from a runtime mount.

On the legacy builder a second failure hit first: `COPY *.py .` matches multiple files, and the legacy builder requires a multi-file `COPY` destination to end in `/`, so the build aborted at that step with *"When using COPY with more than one source file, the destination must be a directory and end with a /"*. BuildKit is lenient here; the legacy builder is not.

## Fix

Collapse the two copies into one and make the config optional:

```dockerfile
COPY *.py config.ym[l] ./
```

- `config.ym[l]` is a bracket glob — it matches `config.yml` when present and silently matches nothing when absent, instead of erroring.
- `*.py` guarantees the `COPY` always has at least one matching source, so it never fails on an empty match.
- The `./` (trailing slash) destination satisfies the multi-file rule on the legacy builder as well as BuildKit.

A build-time check warns when no config was baked in, so the image still builds but the operator knows to mount one:

```dockerfile
RUN test -f config.yml || echo "WARNING: no config.yml baked into image; mount one to /usr/src/app/config.yml at runtime or the bot will exit on startup."
```

## Behavior

- Build succeeds whether or not `config.yml` is in the build context.
- If present, the config is baked into the image as before.
- If absent, the build prints the warning and produces an image that expects a runtime mount at `/usr/src/app/config.yml`. Startup is unchanged, `main.py` already exits cleanly when no config is found.

No TBB code changed, so no version bump.
The v2.0.2 tag will be moved to the new HEAD after merge.
